### PR TITLE
fix: update oci source label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ FROM nginx:alpine
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0
-LABEL org.opencontainers.image.source=https://github.com/opencost/opencost
+LABEL org.opencontainers.image.source=https://github.com/opencost/opencost-ui
 LABEL org.opencontainers.image.title=opencost-ui
 LABEL org.opencontainers.image.url=https://opencost.io
 

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -3,7 +3,7 @@ FROM nginx:alpine
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0
-LABEL org.opencontainers.image.source=https://github.com/opencost/opencost
+LABEL org.opencontainers.image.source=https://github.com/opencost/opencost-ui
 LABEL org.opencontainers.image.title=opencost-ui
 LABEL org.opencontainers.image.url=https://opencost.io
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -6,7 +6,7 @@ FROM nginx:alpine
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0
-LABEL org.opencontainers.image.source=https://github.com/opencost/opencost
+LABEL org.opencontainers.image.source=https://github.com/opencost/opencost-ui
 LABEL org.opencontainers.image.title=opencost-ui
 LABEL org.opencontainers.image.url=https://opencost.io
 


### PR DESCRIPTION
## What does this PR change?

Set the OCI source label to this repo.

## Does this PR relate to any other PRs?

N/A.

## How will this PR impact users?

Since I've worked on this for Renovate, people might loose grouping of this and normal opencost image.  However, I plan to push an update to Renovate as well to fix this.

## Does this PR address any GitHub or Zendesk issues?

N/A.

## How was this PR tested?

```
docker build -t opencost-ui .
docker inspect opencost-ui
```

```json
            "Labels": {
                "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>",
                "org.opencontainers.image.description": "Cross-cloud cost allocation models for Kubernetes workloads",
                "org.opencontainers.image.documentation": "https://opencost.io/docs/",
                "org.opencontainers.image.licenses": "Apache-2.0",
                "org.opencontainers.image.source": "https://github.com/opencost/opencost-ui",
                "org.opencontainers.image.title": "opencost-ui",
                "org.opencontainers.image.url": "https://opencost.io"
            },
```

## Does this PR require changes to documentation?

N/A.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
 
N/A.