### PR TITLE
remove copy thirdparty licenses Signed-off-by: Cliff Colvin <ccolvin@…

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ build-local:
     npx parcel build src/index.html
 
 build IMAGE_TAG RELEASE_VERSION: build-local
-    cp ../{{thirdPartyLicenseFile}} .
     docker buildx build \
         --rm \
         --platform "linux/amd64" \


### PR DESCRIPTION
…kubecost.com>

## What does this PR change?
* removes the justfile cp of third party licenses file, this was a remnant of when the file only existed in ../ from when this was a sub-folder of opencost/opencost.

## Does this PR relate to any other PRs?
* 

## How will this PR impact users?
* 

## Does this PR address any GitHub or Zendesk issues?
* Closes ...

## How was this PR tested?
* 

## Does this PR require changes to documentation?
* 

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
