### PR TITLE
added GPU Cost to a column in allocationReport.js

### DIFF
--- a/src/components/allocationReport.js
+++ b/src/components/allocationReport.js
@@ -48,6 +48,7 @@ function stableSort(array, comparator) {
 const headCells = [
   { id: "name", numeric: false, label: "Name", width: "auto" },
   { id: "cpuCost", numeric: true, label: "CPU", width: 90 },
+  { id: "gpuCost", numeric: true, label: "GPU", width: 90 },
   { id: "ramCost", numeric: true, label: "RAM", width: 90 },
   { id: "pvCost", numeric: true, label: "PV", width: 90 },
   { id: "totalEfficiency", numeric: true, label: "Efficiency", width: 90 },
@@ -186,6 +187,9 @@ const AllocationReport = ({
                       {toCurrency(row.cpuCost, currency)}
                     </TableCell>
                     <TableCell align="right">
+                      {toCurrency(row.gpuCost, currency)}
+                    </TableCell>
+                    <TableCell align="right">
                       {toCurrency(row.ramCost, currency)}
                     </TableCell>
                     <TableCell align="right">
@@ -208,6 +212,9 @@ const AllocationReport = ({
                   <TableCell align="left">{row.name}</TableCell>
                   <TableCell align="right">
                     {toCurrency(row.cpuCost, currency)}
+                  </TableCell>
+                  <TableCell align="right">
+                    {toCurrency(row.gpuCost, currency)}
                   </TableCell>
                   <TableCell align="right">
                     {toCurrency(row.ramCost, currency)}


### PR DESCRIPTION
## What does this PR change?
Adds a column to the main page for GPU cost between CPU and RAM

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Adds a column for GPU

## Does this PR address any GitHub or Zendesk issues?
* Closes #7 

## How was this PR tested?
Ran on local opencost instance with GPU costs appropriately reported. 

## Does this PR require changes to documentation?
no

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
Not sure if GPU cost needs to be conditional, nor if this is the particular fix.
