### PR TITLE
Adjust permissions to allow image to run in OpenShift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,12 @@ COPY ./docker-entrypoint.sh /usr/local/bin/
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
-RUN chown 1001:1000 -R /var/www
-RUN chown 1001:1000 -R /etc/nginx
-RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
+RUN chown 1001:0 -R /var/www && \
+    chmod -R g=u /var/www
+RUN chown 1001:0 -R /etc/nginx && \
+    chmod -R g=u /etc/nginx
+RUN chown 1001:0 -R /usr/local/bin/docker-entrypoint.sh && \
+    chmod 775 /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -26,9 +26,12 @@ RUN mkdir -p /var/www
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
-RUN chown 1001:1000 -R /var/www
-RUN chown 1001:1000 -R /etc/nginx
-RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
+RUN chown 1001:0 -R /var/www && \
+    chmod -R g=u /var/www
+RUN chown 1001:0 -R /etc/nginx && \
+    chmod -R g=u /etc/nginx
+RUN chown 1001:0 -R /usr/local/bin/docker-entrypoint.sh && \
+    chmod 775 /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -28,9 +28,12 @@ RUN mkdir -p /var/www
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
 RUN adduser 1001 -g 1000 -D
-RUN chown 1001:1000 -R /var/www
-RUN chown 1001:1000 -R /etc/nginx
-RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
+RUN chown 1001:0 -R /var/www && \
+    chmod -R g=u /var/www
+RUN chown 1001:0 -R /etc/nginx && \
+    chmod -R g=u /etc/nginx
+RUN chown 1001:0 -R /usr/local/bin/docker-entrypoint.sh && \
+    chmod 775 /usr/local/bin/docker-entrypoint.sh
 
 ENV BASE_URL=/model
 


### PR DESCRIPTION
see: https://developers.redhat.com/blog/2020/10/26/adapting-docker-and-kubernetes-containers-to-run-on-red-hat-openshift-container-platform

## What does this PR change?
It allows the image to run in OpenShift (currently, permission problems prevent the image from running)

## Does this PR relate to any other PRs?
No

## How will this PR impact users?
Users will be able to run the image in OpenShift

## Does this PR address any GitHub or Zendesk issues?
No

## How was this PR tested?
In OpenShift

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
I don't seem to be able to do that
