### PR TITLE
only create /etc/nginx/conf.d/default.nginx.conf if it does not yet exist (fix #4)

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,8 +18,9 @@ else
     sed -i "s^PLACEHOLDER_FOOTER_CONTENT^OpenCost version: $VERSION ($HEAD)^g" /var/www/*.js
 fi
 
-envsubst '$API_PORT $API_SERVER $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
-
+if [[ ! -e /etc/nginx/conf.d/default.nginx.conf ]];then
+    envsubst '$API_PORT $API_SERVER $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
+fi
 echo "Starting OpenCost UI version $VERSION ($HEAD)"
 
 # Run the parent (nginx) container's entrypoint script


### PR DESCRIPTION
## What does this PR change?

The `docker-entrypoint.sh` does not create the `/etc/nginx/conf.d/default.nginx.conf` file, if it already exist. This way, people can workaround issue #4 more easily by mounting the configuration file from a configMap. Not nice, but working...

## Does this PR relate to any other PRs?

No.

## How will this PR impact users?

This should have no impact on normal users, other than helping users that want to have `readOnlyRootFilesystem` set to true or are using OpenShift.

## Does this PR address any GitHub or Zendesk issues?

Allows to workaround #4

## How was this PR tested?

I cannot test this unfortunately.

## Does this PR require changes to documentation?

If this is the only workaround to #4, then this could be documented in the helm chart.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

I have not labelled it, as I am not sure if this is a good idea to have this workaround or if this should be fixed properly...
