### PR TITLE
Update allocationReport.js

### DIFF
--- a/src/components/allocationReport.js
+++ b/src/components/allocationReport.js
@@ -45,6 +45,14 @@ function stableSort(array, comparator) {
   return stabilizedThis.map((el) => el[0]);
 }
 
+// ✅ Helper function to build display name with namespace
+function getDisplayName(row) {
+  if (row.namespace) {
+    return `${row.namespace}:${row.name}`;
+  }
+  return row.name;
+}
+
 const headCells = [
   { id: "name", numeric: false, label: "Name", width: "auto" },
   { id: "cpuCost", numeric: true, label: "CPU", width: 90 },
@@ -159,6 +167,7 @@ const AllocationReport = ({
                 );
               })}
             </TableRow>
+
             {pageRows.map((row, key) => {
               if (row.name === "__unmounted__") {
                 row.name = "Unmounted PVs";
@@ -178,11 +187,10 @@ const AllocationReport = ({
                 efficiency = "Inf";
               }
 
-              // Do not allow drill-down for idle and unallocated rows
               if (isIdle || isUnallocated || isUnmounted) {
                 return (
                   <TableRow key={key}>
-                    <TableCell align="left">{row.name}</TableCell>
+                    <TableCell align="left">{getDisplayName(row)}</TableCell>
                     <TableCell align="right">
                       {toCurrency(row.cpuCost, currency)}
                     </TableCell>
@@ -209,7 +217,7 @@ const AllocationReport = ({
 
               return (
                 <TableRow key={key}>
-                  <TableCell align="left">{row.name}</TableCell>
+                  <TableCell align="left">{getDisplayName(row)}</TableCell>
                   <TableCell align="right">
                     {toCurrency(row.cpuCost, currency)}
                   </TableCell>


### PR DESCRIPTION
## What does this PR change?
* Updates the Allocation Report UI to include the **namespace** when displaying the resource name.
* Now shows names in the format: `namespace:controller:podname` (or `namespace:resource`).

## Does this PR relate to any other PRs?
* No, this is a standalone fix.

## How will this PR impact users?
* Users can now **differentiate same-named deployments, pods, or services** across different namespaces in the Allocations view.
* Improves cost reporting clarity for multi-tenant Kubernetes clusters.

## Does this PR address any GitHub or Zendesk issues?
* Closes [#1964](https://github.com/opencost/opencost/issues/1964) — "Include namespace in UI/metrics"

## How was this PR tested?
* Ran frontend locally using `npm start`.
* Verified that allocation rows now show `namespace:resource` format correctly.
* Verified fallback behavior — if namespace is missing, display only the resource name.

## Does this PR require changes to documentation?
* No changes needed. This is a UI display enhancement only.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* No, this is a minor UI improvement and can be merged under normal releases without special labeling.
