### PR TITLE
feat: Add support for multiple aggregations in cost allocation view

### DIFF
--- a/src/components/Controls/Edit.js
+++ b/src/components/Controls/Edit.js
@@ -1,8 +1,10 @@
+import Box from '@material-ui/core/Box';
+import Chip from '@material-ui/core/Chip';
+import FormControl from '@material-ui/core/FormControl';
+import InputLabel from '@material-ui/core/InputLabel';
+import MenuItem from '@material-ui/core/MenuItem';
+import Select from '@material-ui/core/Select';
 import { makeStyles } from '@material-ui/styles';
-import FormControl from '@material-ui/core/FormControl'
-import InputLabel from '@material-ui/core/InputLabel'
-import MenuItem from '@material-ui/core/MenuItem'
-import Select from '@material-ui/core/Select'
 
 import React from 'react';
 
@@ -16,6 +18,14 @@ const useStyles = makeStyles({
     margin: 8,
     minWidth: 120,
   },
+  chips: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 0.5,
+  },
+  chip: {
+    margin: 2,
+  },
 });
 
 function EditControl({
@@ -25,6 +35,13 @@ function EditControl({
   currencyOptions, currency, setCurrency,
 }) {
   const classes = useStyles();
+
+  // Handle multiple aggregations
+  const handleAggregationChange = (event) => {
+    const value = event.target.value;
+    setAggregateBy(value);
+  };
+
   return (
     <div className={classes.wrapper}>
       <SelectWindow
@@ -35,12 +52,26 @@ function EditControl({
         <InputLabel id="aggregation-select-label">Breakdown</InputLabel>
         <Select
           id="aggregation-select"
-          value={aggregateBy}
-          onChange={e => {
-            setAggregateBy(e.target.value)
-          }}
+          multiple
+          value={Array.isArray(aggregateBy) ? aggregateBy : [aggregateBy]}
+          onChange={handleAggregationChange}
+          renderValue={(selected) => (
+            <Box className={classes.chips}>
+              {selected.map((value) => (
+                <Chip
+                  key={value}
+                  label={aggregationOptions.find(opt => opt.value === value)?.name || value}
+                  className={classes.chip}
+                />
+              ))}
+            </Box>
+          )}
         >
-          {aggregationOptions.map((opt) => <MenuItem key={opt.value} value={opt.value}>{opt.name}</MenuItem>)}
+          {aggregationOptions.map((opt) => (
+            <MenuItem key={opt.value} value={opt.value}>
+              {opt.name}
+            </MenuItem>
+          ))}
         </Select>
       </FormControl>
       <FormControl className={classes.formControl}>
@@ -53,22 +84,20 @@ function EditControl({
           {accumulateOptions.map((opt) => <MenuItem key={opt.value} value={opt.value}>{opt.name}</MenuItem>)}
         </Select>
       </FormControl>
-      <FormControl className={classes.formControl}>
-        <InputLabel id="currency-label">Currency</InputLabel>
-        <Select
-          id="currency"
-          value={currency}
-          onChange={e => setCurrency(e.target.value)}
-        >
-          {currencyOptions?.map((currency) => (
-            <MenuItem key={currency} value={currency}>
-              {currency}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      {currencyOptions && (
+        <FormControl className={classes.formControl}>
+          <InputLabel id="currency-select-label">Currency</InputLabel>
+          <Select
+            id="currency-select"
+            value={currency}
+            onChange={e => setCurrency(e.target.value)}
+          >
+            {currencyOptions.map((opt) => <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
+          </Select>
+        </FormControl>
+      )}
     </div>
   );
 }
 
-export default React.memo(EditControl);
+export default EditControl;

--- a/src/pages/Allocations.js
+++ b/src/pages/Allocations.js
@@ -5,34 +5,28 @@ import Typography from "@material-ui/core/Typography";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import { makeStyles } from "@material-ui/styles";
 import {
-  filter,
   find,
-  forEach,
   get,
-  isArray,
   sortBy,
-  toArray,
-  trim,
+  toArray
 } from "lodash";
 import React, { useEffect, useState } from "react";
-import ReactDOM from "react-dom";
-import { useLocation, useHistory } from "react-router";
+import { useHistory, useLocation } from "react-router";
 
 import AllocationReport from "../components/allocationReport";
 import Controls from "../components/Controls";
+import Footer from "../components/Footer";
 import Header from "../components/Header";
 import Page from "../components/Page";
-import Footer from "../components/Footer";
 import Subtitle from "../components/Subtitle";
 import Warnings from "../components/Warnings";
-import AllocationService from "../services/allocation";
+import { currencyCodes } from "../constants/currencyCodes";
 import {
   checkCustomWindow,
   cumulativeToTotals,
   rangeToCumulative,
   toVerboseTimeRange,
 } from "../util";
-import { currencyCodes } from "../constants/currencyCodes";
 
 const windowOptions = [
   { name: "Today", value: "today" },
@@ -123,7 +117,7 @@ const ReportsPage = () => {
   // Form state, which controls form elements, but not the report itself. On
   // certain actions, the form state may flow into the report state.
   const [window, setWindow] = useState(windowOptions[0].value);
-  const [aggregateBy, setAggregateBy] = useState(aggregationOptions[0].value);
+  const [aggregateBy, setAggregateBy] = useState([aggregationOptions[0].value]);
   const [accumulate, setAccumulate] = useState(accumulateOptions[0].value);
   const [currency, setCurrency] = useState("USD");
 
@@ -159,7 +153,8 @@ const ReportsPage = () => {
   const routerHistory = useHistory();
   useEffect(() => {
     setWindow(searchParams.get("window") || "7d");
-    setAggregateBy(searchParams.get("agg") || "namespace");
+    const aggParam = searchParams.get("agg");
+    setAggregateBy(aggParam ? aggParam.split(",") : [aggregationOptions[0].value]);
     setAccumulate(searchParams.get("acc") === "true" || false);
     setCurrency(searchParams.get("currency") || "USD");
   }, [routerLocation]);
@@ -230,8 +225,8 @@ const ReportsPage = () => {
     setFetch(false);
   }
   return (
-    <Page active="reports.html">
-       <Header headerTitle='Cost Allocation'>
+    <Page active="allocations.html">
+      <Header headerTitle='Allocations'>
         <IconButton aria-label="refresh" onClick={() => setFetch(true)}>
           <RefreshIcon />
         </IconButton>
@@ -263,7 +258,7 @@ const ReportsPage = () => {
               aggregationOptions={aggregationOptions}
               aggregateBy={aggregateBy}
               setAggregateBy={(agg) => {
-                searchParams.set("agg", agg);
+                searchParams.set("agg", Array.isArray(agg) ? agg.join(",") : agg);
                 routerHistory.push({
                   search: `?${searchParams.toString()}`,
                 });
@@ -306,7 +301,7 @@ const ReportsPage = () => {
           )}
         </Paper>
       )}
-      <Footer/>
+      <Footer />
     </Page>
   );
 };


### PR DESCRIPTION
## What does this PR change?
This PR adds support for multiple aggregations in the cost allocation view, allowing users to analyze costs across multiple dimensions simultaneously.

fixes #9 

![Screenshot from 2025-05-14 06-38-55](https://github.com/user-attachments/assets/b1111cd9-41da-48d7-ba65-04c85ce4feca)


@mattray @ameijer