### PR TITLE
Fix deprecated and missing props in TablePagination

### DIFF
--- a/src/components/allocationReport.js
+++ b/src/components/allocationReport.js
@@ -238,8 +238,8 @@ const AllocationReport = ({
         rowsPerPage={rowsPerPage}
         rowsPerPageOptions={[10, 25, 50]}
         page={Math.min(page, lastPage)}
-        onChangePage={handleChangePage}
-        onChangeRowsPerPage={handleChangeRowsPerPage}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
       />
     </div>
   );

--- a/src/components/cloudCost/cloudCost.js
+++ b/src/components/cloudCost/cloudCost.js
@@ -204,8 +204,8 @@ const CloudCost = ({
           rowsPerPage={rowsPerPage}
           rowsPerPageOptions={[10, 25, 50]}
           page={Math.min(page, lastPage)}
-          onChangePage={handleChangePage}
-          onChangeRowsPerPage={handleChangeRowsPerPage}
+          onPageChange={handleChangePage}
+          onRowsPerPageChange={handleChangeRowsPerPage}
         />
       </div>
     </div>

--- a/src/components/externalCosts/externalCostsTable.js
+++ b/src/components/externalCosts/externalCostsTable.js
@@ -168,8 +168,8 @@ const ExternalCostsTable = ({
         rowsPerPage={rowsPerPage}
         rowsPerPageOptions={[10, 25, 50]}
         page={Math.min(page, lastPage)}
-        onChangePage={handleChangePage}
-        onChangeRowsPerPage={handleChangeRowsPerPage}
+        onPageChange={handleChangePage}
+        onRowsPerPageChange={handleChangeRowsPerPage}
       />
     </div>
   );


### PR DESCRIPTION
## What does this PR change?
* Updates deprecated props onChangePage and onChangeRowsPerPage to onPageChange and onRowsPerPageChange in TablePagination components.

- Fixes missing required prop onPageChange that caused console warnings.

## Does this PR relate to any other PRs?
* No direct relation to other PRs.

## How will this PR impact users?
* Eliminates console warning errors related to TablePagination usage, improving developer experience and code compatibility with Material UI v5.

## Does this PR address any GitHub or Zendesk issues?
* Closes #83 

## How was this PR tested?
* Manually debugged and ran the UI components in allocationReport.js, cloudCost.js, and externalCostsTable.js to verify pagination works correctly without console errors.

## Does this PR require changes to documentation?
* No
