### PR TITLE
Revert "feat: Add support for multiple aggregations in cost allocation view"

### DIFF
--- a/src/components/Controls/Edit.js
+++ b/src/components/Controls/Edit.js
@@ -1,10 +1,8 @@
-import Box from '@material-ui/core/Box';
-import Chip from '@material-ui/core/Chip';
-import FormControl from '@material-ui/core/FormControl';
-import InputLabel from '@material-ui/core/InputLabel';
-import MenuItem from '@material-ui/core/MenuItem';
-import Select from '@material-ui/core/Select';
 import { makeStyles } from '@material-ui/styles';
+import FormControl from '@material-ui/core/FormControl'
+import InputLabel from '@material-ui/core/InputLabel'
+import MenuItem from '@material-ui/core/MenuItem'
+import Select from '@material-ui/core/Select'
 
 import React from 'react';
 
@@ -18,14 +16,6 @@ const useStyles = makeStyles({
     margin: 8,
     minWidth: 120,
   },
-  chips: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: 0.5,
-  },
-  chip: {
-    margin: 2,
-  },
 });
 
 function EditControl({
@@ -35,13 +25,6 @@ function EditControl({
   currencyOptions, currency, setCurrency,
 }) {
   const classes = useStyles();
-
-  // Handle multiple aggregations
-  const handleAggregationChange = (event) => {
-    const value = event.target.value;
-    setAggregateBy(value);
-  };
-
   return (
     <div className={classes.wrapper}>
       <SelectWindow
@@ -52,26 +35,12 @@ function EditControl({
         <InputLabel id="aggregation-select-label">Breakdown</InputLabel>
         <Select
           id="aggregation-select"
-          multiple
-          value={Array.isArray(aggregateBy) ? aggregateBy : [aggregateBy]}
-          onChange={handleAggregationChange}
-          renderValue={(selected) => (
-            <Box className={classes.chips}>
-              {selected.map((value) => (
-                <Chip
-                  key={value}
-                  label={aggregationOptions.find(opt => opt.value === value)?.name || value}
-                  className={classes.chip}
-                />
-              ))}
-            </Box>
-          )}
+          value={aggregateBy}
+          onChange={e => {
+            setAggregateBy(e.target.value)
+          }}
         >
-          {aggregationOptions.map((opt) => (
-            <MenuItem key={opt.value} value={opt.value}>
-              {opt.name}
-            </MenuItem>
-          ))}
+          {aggregationOptions.map((opt) => <MenuItem key={opt.value} value={opt.value}>{opt.name}</MenuItem>)}
         </Select>
       </FormControl>
       <FormControl className={classes.formControl}>
@@ -84,20 +53,22 @@ function EditControl({
           {accumulateOptions.map((opt) => <MenuItem key={opt.value} value={opt.value}>{opt.name}</MenuItem>)}
         </Select>
       </FormControl>
-      {currencyOptions && (
-        <FormControl className={classes.formControl}>
-          <InputLabel id="currency-select-label">Currency</InputLabel>
-          <Select
-            id="currency-select"
-            value={currency}
-            onChange={e => setCurrency(e.target.value)}
-          >
-            {currencyOptions.map((opt) => <MenuItem key={opt} value={opt}>{opt}</MenuItem>)}
-          </Select>
-        </FormControl>
-      )}
+      <FormControl className={classes.formControl}>
+        <InputLabel id="currency-label">Currency</InputLabel>
+        <Select
+          id="currency"
+          value={currency}
+          onChange={e => setCurrency(e.target.value)}
+        >
+          {currencyOptions?.map((currency) => (
+            <MenuItem key={currency} value={currency}>
+              {currency}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
     </div>
   );
 }
 
-export default EditControl;
+export default React.memo(EditControl);

--- a/src/pages/Allocations.js
+++ b/src/pages/Allocations.js
@@ -5,28 +5,34 @@ import Typography from "@material-ui/core/Typography";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import { makeStyles } from "@material-ui/styles";
 import {
+  filter,
   find,
+  forEach,
   get,
+  isArray,
   sortBy,
-  toArray
+  toArray,
+  trim,
 } from "lodash";
 import React, { useEffect, useState } from "react";
-import { useHistory, useLocation } from "react-router";
+import ReactDOM from "react-dom";
+import { useLocation, useHistory } from "react-router";
 
 import AllocationReport from "../components/allocationReport";
 import Controls from "../components/Controls";
-import Footer from "../components/Footer";
 import Header from "../components/Header";
 import Page from "../components/Page";
+import Footer from "../components/Footer";
 import Subtitle from "../components/Subtitle";
 import Warnings from "../components/Warnings";
-import { currencyCodes } from "../constants/currencyCodes";
+import AllocationService from "../services/allocation";
 import {
   checkCustomWindow,
   cumulativeToTotals,
   rangeToCumulative,
   toVerboseTimeRange,
 } from "../util";
+import { currencyCodes } from "../constants/currencyCodes";
 
 const windowOptions = [
   { name: "Today", value: "today" },
@@ -117,7 +123,7 @@ const ReportsPage = () => {
   // Form state, which controls form elements, but not the report itself. On
   // certain actions, the form state may flow into the report state.
   const [window, setWindow] = useState(windowOptions[0].value);
-  const [aggregateBy, setAggregateBy] = useState([aggregationOptions[0].value]);
+  const [aggregateBy, setAggregateBy] = useState(aggregationOptions[0].value);
   const [accumulate, setAccumulate] = useState(accumulateOptions[0].value);
   const [currency, setCurrency] = useState("USD");
 
@@ -153,8 +159,7 @@ const ReportsPage = () => {
   const routerHistory = useHistory();
   useEffect(() => {
     setWindow(searchParams.get("window") || "7d");
-    const aggParam = searchParams.get("agg");
-    setAggregateBy(aggParam ? aggParam.split(",") : [aggregationOptions[0].value]);
+    setAggregateBy(searchParams.get("agg") || "namespace");
     setAccumulate(searchParams.get("acc") === "true" || false);
     setCurrency(searchParams.get("currency") || "USD");
   }, [routerLocation]);
@@ -225,8 +230,8 @@ const ReportsPage = () => {
     setFetch(false);
   }
   return (
-    <Page active="allocations.html">
-      <Header headerTitle='Allocations'>
+    <Page active="reports.html">
+       <Header headerTitle='Cost Allocation'>
         <IconButton aria-label="refresh" onClick={() => setFetch(true)}>
           <RefreshIcon />
         </IconButton>
@@ -258,7 +263,7 @@ const ReportsPage = () => {
               aggregationOptions={aggregationOptions}
               aggregateBy={aggregateBy}
               setAggregateBy={(agg) => {
-                searchParams.set("agg", Array.isArray(agg) ? agg.join(",") : agg);
+                searchParams.set("agg", agg);
                 routerHistory.push({
                   search: `?${searchParams.toString()}`,
                 });
@@ -301,7 +306,7 @@ const ReportsPage = () => {
           )}
         </Paper>
       )}
-      <Footer />
+      <Footer/>
     </Page>
   );
 };


### PR DESCRIPTION
Reverts opencost/opencost-ui#82

Right now due to [this PR](https://github.com/opencost/opencost-ui/pull/82) all the api request are going incorrectly.
```
https://demo.infra.opencost.io/[object%20Object]
```
---
Related issue:
https://github.com/opencost/opencost-helm-chart/issues/280

To Reproduce:
Check the Allocation page on https://demo.infra.opencost.io/

Tested:
Checked that opencost-ui 1.114.0 is working fine and this was the only code change between 1.114.0 and 1.115.0
Tested by creating a custom image on this branch with reverted changes: opencost-ui loads correctly
![Screenshot 2025-06-09 at 4 00 32 PM](https://github.com/user-attachments/assets/e92ce5d2-ac23-442c-9bb9-848abe2679fd)


Lets revert this change for now and update the opencost-ui 1.115.0 image to get it fixed.