### PR TITLE
fix images and loading of external costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # OpenCost UI
 
-<img src="./opencost-header.png"/>
+<img src="src/images/logo.png"/>
 
 This is the web UI for the [OpenCost](http://github.com/opencost/opencost) project. You can learn more about the [User Interface](https://www.opencost.io/docs/installation/ui) in the OpenCost docs.
 
-[![OpenCost UI Walkthrough](./ui/src/thumbnail.png)](https://youtu.be/lCP4Ci9Kcdg)
+[![OpenCost UI Walkthrough](./src/thumbnail.png)](https://youtu.be/lCP4Ci9Kcdg)
 *OpenCost UI Walkthrough*
 
 ## Installing

--- a/src/components/Nav/SidebarNav.js
+++ b/src/components/Nav/SidebarNav.js
@@ -6,6 +6,8 @@ import { BarChart } from "@material-ui/icons";
 import { Cloud } from "@material-ui/icons";
 import { makeStyles } from "@material-ui/styles";
 
+const logo = new URL("../../images/logo.png", import.meta.url).href;
+
 const DRAWER_WIDTH = 200;
 
 const SidebarNav = ({ active }) => {
@@ -55,7 +57,7 @@ const SidebarNav = ({ active }) => {
       variant={"permanent"}
     >
       <img
-        src={require("../../images/logo.png")}
+        src={logo}
         alt="OpenCost"
         style={{ flexShrink: 1, padding: "1rem" }}
       />

--- a/src/components/externalCosts/externalCostsTable.js
+++ b/src/components/externalCosts/externalCostsTable.js
@@ -56,7 +56,7 @@ const ExternalCostsTable = ({
   const routerHistory = useHistory();
   const [page, setPage] = React.useState(0);
   const [rowsPerPage, setRowsPerPage] = React.useState(25);
-  const numData = tableData.customCosts?.length;
+  const numData = tableData.customCosts?.length ?? 0;
 
   const lastPage = Math.floor(numData / rowsPerPage);
 
@@ -67,16 +67,20 @@ const ExternalCostsTable = ({
     setPage(0);
   };
 
-  const pageRows = tableData.customCosts.slice(
-    page * rowsPerPage,
-    page * rowsPerPage + rowsPerPage
-  );
+  let pageRows = [];
+
+  if (tableData && 'customCosts' in tableData) {
+    pageRows = tableData.customCosts.slice(
+        page * rowsPerPage,
+        page * rowsPerPage + rowsPerPage
+    );
+  }
 
   React.useEffect(() => {
     setPage(0);
   }, [numData]);
 
-  if (tableData.customCosts.length === 0) {
+  if ('customCosts' in tableData && tableData.customCosts.length === 0) {
     return (
       <Typography variant="body2" className={classes.noResults}>
         No results


### PR DESCRIPTION
## What does this PR change?
It fixes the images in the Readme and the UI, the opencost logo was not showing. Additionally, I fixed the loading of the ExternalCostsTable if there is no data, previously it showed a blank page.

| before | after |
|--------|--------|
| <img width="963" height="443" alt="image" src="https://github.com/user-attachments/assets/67f8c68d-a60e-48d4-bf30-87df8c59b9b2" /> | <img width="954" height="287" alt="image" src="https://github.com/user-attachments/assets/ae20ab7a-b3d6-4407-b079-e0e34f5d7592" /> | 
| <img width="1800" height="766" alt="image" src="https://github.com/user-attachments/assets/9483ba44-f0dd-4b48-a069-8985ad1b3c4e" /> | <img width="1800" height="949" alt="image" src="https://github.com/user-attachments/assets/09171304-ba08-48aa-bddc-cf09467e27b2" /> |
## Does this PR relate to any other PRs?
No

## How will this PR impact users?
It will improve the UI for the users as it will show the image correctly.

## Does this PR address any GitHub or Zendesk issues?
No

## How was this PR tested?
Running the UI locally and verifying if the images are loaded.

## Does this PR require changes to documentation?
No

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
~I will label it~ i cant
