### PR TITLE
Add step to checkout opencost-ui in Build and Publish Release workflow

### DIFF
--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -66,6 +66,12 @@ jobs:
           ref: '${{ steps.branch.outputs.BRANCH_NAME }}'
           path: ./opencost-ui
 
+      # checkout opencost UI to allow access to actions
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        with:
+          repository: 'opencost/opencost-ui'
+
       - name: Set SHA
         id: sha
         run: |

--- a/.github/workflows/build-and-publish-release.yml
+++ b/.github/workflows/build-and-publish-release.yml
@@ -81,7 +81,6 @@ jobs:
           echo "IMAGE_TAG_UI_VERSION=ghcr.io/opencost/opencost-ui:${{ steps.version_number.outputs.RELEASE_VERSION }}" >> $GITHUB_OUTPUT
 
       - name: Build and publish container
-        working-directory: ./opencost-ui
         uses: ./.github/actions/build-container
         with:
           actor: ${{ github.actor }}


### PR DESCRIPTION
## What does this PR change?
* Adds a step to checkout opencost-ui in `Build and Publish Release` workflow

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* N/A

## Does this PR address any GitHub or Zendesk issues?
* Closes ... N/A

## How was this PR tested?
* Via failing release workflow debugging

## Does this PR require changes to documentation?
* N/A

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* N/A - Infra change
