### PR TITLE
Add support for custom UI path

### DIFF
--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -7,14 +7,16 @@ LABEL org.opencontainers.image.source=https://github.com/opencost/opencost-ui
 LABEL org.opencontainers.image.title=opencost-ui
 LABEL org.opencontainers.image.url=https://opencost.io
 
+ARG ui_path=/
 ARG version=dev
-ARG	commit=HEAD
+ARG commit=HEAD
 ENV VERSION=${version}
 ENV HEAD=${commit}
 
 ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
+ENV UI_PATH=${ui_path}
 
 COPY ./dist /opt/ui/dist
 COPY THIRD_PARTY_LICENSES.txt /THIRD_PARTY_LICENSES.txt
@@ -30,7 +32,7 @@ RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
 RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
-ENV BASE_URL=/model
+ENV BASE_URL=${UI_PATH%/}/model
 
 USER 1001
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -10,14 +10,16 @@ LABEL org.opencontainers.image.source=https://github.com/opencost/opencost-ui
 LABEL org.opencontainers.image.title=opencost-ui
 LABEL org.opencontainers.image.url=https://opencost.io
 
+ARG ui_path=/
 ARG version=dev
-ARG	commit=HEAD
+ARG commit=HEAD
 ENV VERSION=${version}
 ENV HEAD=${commit}
 
 ENV API_PORT=9003
 ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
+ENV UI_PATH=${ui_path}
 
 COPY ./dist /opt/ui/dist
 COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
@@ -32,7 +34,7 @@ RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
 RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
-ENV BASE_URL=/model
+ENV BASE_URL=${UI_PATH%/}/model
 
 USER 1001
 

--- a/README.md
+++ b/README.md
@@ -62,3 +62,16 @@ For some use cases such as the case of [OpenCost deployed behind an ingress cont
 ```sh
 $ docker run -p 9091:9090 -e BASE_URL_OVERRIDE=anything -d opencost-ui:latest
 ```
+
+## Overriding the Base UI URL Path
+
+To serve the web interface under a path other than the root (`/`), you need to build a custom image using the `ui_path` build argument.  
+For example, you can clone this project and run:
+
+```sh
+$ docker build --build-arg ui_path=/anything --tag opencost-ui:latest .
+```
+
+This ensures that all static assets are served from the specified path.
+
+Once the container is running, the UI will be accessible at `<domain>/{ui_path}`.

--- a/default.nginx.conf.template
+++ b/default.nginx.conf.template
@@ -51,9 +51,9 @@ server {
     }
 
     add_header Cache-Control "max-age=300";
-    location / {
-        root /var/www;
-        index index.html index.htm;
+
+    location ${UI_PATH} {
+        alias /var/www/;
         try_files $uri /index.html;
     }
 
@@ -65,7 +65,7 @@ server {
         access_log /dev/null;
         return 200 'OK';
     }
-    location /model/ {
+    location ${BASE_URL}/ {
         proxy_connect_timeout       180;
         proxy_send_timeout          180;
         proxy_read_timeout          180;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -3,6 +3,8 @@ set -e
 
 cp -rv /opt/ui/dist/* /var/www
 
+echo "running with UI_PATH=${UI_PATH}"
+
 if [[ ! -z "$BASE_URL_OVERRIDE" ]]; then
     echo "running with BASE_URL=${BASE_URL_OVERRIDE}"
     sed -i "s^{PLACEHOLDER_BASE_URL}^$BASE_URL_OVERRIDE^g" /var/www/*.js
@@ -19,7 +21,9 @@ else
 fi
 
 if [[ ! -e /etc/nginx/conf.d/default.nginx.conf ]];then
-    envsubst '$API_PORT $API_SERVER $UI_PORT' < /etc/nginx/conf.d/default.nginx.conf.template > /etc/nginx/conf.d/default.nginx.conf
+    envsubst '$API_PORT $API_SERVER $UI_PORT $UI_PATH $BASE_URL' \
+        < /etc/nginx/conf.d/default.nginx.conf.template \
+        > /etc/nginx/conf.d/default.nginx.conf
 fi
 echo "Starting OpenCost UI version $VERSION ($HEAD)"
 

--- a/src/route.js
+++ b/src/route.js
@@ -5,9 +5,11 @@ import Reports from "./pages/Allocations.js";
 import CloudCosts from "./pages/CloudCosts.js";
 import ExternalCosts from "./pages/ExternalCosts.js";
 
+const basename = (process.env.UI_PATH || "").replace(/\/+$/, "");
+
 const Routes = () => {
   return (
-    <Router>
+    <Router basename={basename}>
       <Switch>
         <Route exact path="/">
           <Reports />


### PR DESCRIPTION
## What does this PR change?

- This PR allows serving the OpenCost UI from a customizable path instead of the default root ("/").  
   Main changes include:

  - **Dockerfile**: added new build argument (`ui_path`) to support building custom images with a desired base path for serving the UI.
  - **default.nginx.conf.template**: updated to serve the UI from a variable route.
  - **docker-entrypoint.sh**: updated to replace `$UI_PATH` and `$BASE_URL` variables in the nginx configuration.
  - **src/route.js**: updated `basename` usage to allow serving pages from a non-root path.

## Does this PR relate to any other PRs?
* No direct relation.

## How will this PR impact users?
* **End users**: No direct impact. The application will continue to be served at the root path (`/`) by default.

* **Developers**: Gain flexibility to configure and serve the UI from a custom path using the new build argument (`ui_path`). This makes it easier to run the application under subpaths without requiring manual code changes or custom Nginx configuration.

## Does this PR address any GitHub or Zendesk issues?
* This PR is related to several existing issues in this repository and others that requested a customizable base path for the UI, but none of them provided a complete solution:
  - https://github.com/opencost/opencost-ui/issues/6 
  - https://github.com/opencost/opencost/issues/2431 
  - https://github.com/opencost/opencost-helm-chart/issues/148 
  - https://github.com/opencost/opencost-helm-chart/issues/238 
  - https://github.com/opencost/opencost/issues/1677

## How was this PR tested?
* Local execution:
  ```sh
   $ export UI_PATH="/opencost"
   $ npm run serve
  ```
  The UI will be accessible at: `http://localhost:1234/opencost`

* Container execution:
  ```sh
  # Build
  $ docker build --build-arg ui_path=/opencost --tag opencost-ui:latest .

  # Run
  $ docker run -p 9090:9090 opencost-ui:latest
  ```
  The UI will be accessible at: `http://localhost:9090/opencost`
  
## Does this PR require changes to documentation?
* Yes, the README has been updated.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* I am not sure about the release cycle for this project. I am available to make any necessary updates or apply the appropriate labels.
