### PR TITLE
Fix a bug introduced when creating the centralized API client

### DIFF
--- a/src/services/api_client.js
+++ b/src/services/api_client.js
@@ -1,11 +1,14 @@
 /**
  * Provide an axios client defining any configurations consistently used when communicating with an opencost server.
- * 
+ *
  * We should use this client when performing XHR requests across the application, rather than using `fetch` or `axios` directly.
  */
 import axios from "axios";
 
-const baseURL = process.env.BASE_URL || "http://localhost:9090/model";
+let baseURL = process.env.BASE_URL || "{PLACEHOLDER_BASE_URL}";
+if (baseURL.includes("PLACEHOLDER_BASE_URL")) {
+  baseURL = "http://localhost:9090";
+}
 
 const client = axios.create({ baseURL });
 


### PR DESCRIPTION
## What does this PR change?
* Fixes a bug introduced when the unified api client was added.

When adding the API client, I attempted to deduplicate some logic that looked like this:

```javascript
let baseURL = process.env.BASE_URL || '{PLACEHOLDER_BASE_URL}';
if (baseURL.includes('PLACEHOLDER_BASE_URL')) {
  baseURL = 'http://localhost:9090';
}
```

I figured this could be better written as

```javascript
const baseURL = process.env.BASE_URL || 'http://localhost:9090';
```

I did not realize we perform string substitution with an env var in the docker entrypoint file, meaning that `{PLACEHOLDER_BASE_URL}` is an important template string.

## Does this PR relate to any other PRs?
* No.

## How will this PR impact users?
* Un-breaks the app.

## Does this PR address any GitHub or Zendesk issues?
* No.

## How was this PR tested?
* It hasn't been. It can't be tested via local dev, and needs to actually have a built/deployed docker container, which I have not done. I can do that if it's required.

## Does this PR require changes to documentation?
* No.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* 
