### PR TITLE
Configurable timeout preferences. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 ENV UI_PATH=${ui_path}
 
+# Nginx proxy timeout configuration (in seconds)
+ENV PROXY_CONNECT_TIMEOUT=180
+ENV PROXY_SEND_TIMEOUT=180
+ENV PROXY_READ_TIMEOUT=180
+
 COPY --from=builder /opt/ui/dist /opt/ui/dist
 RUN mkdir -p /var/www
 

--- a/default.nginx.conf.template
+++ b/default.nginx.conf.template
@@ -66,9 +66,9 @@ server {
         return 200 'OK';
     }
     location ${BASE_URL}/ {
-        proxy_connect_timeout       180;
-        proxy_send_timeout          180;
-        proxy_read_timeout          180;
+        proxy_connect_timeout       ${PROXY_CONNECT_TIMEOUT};
+        proxy_send_timeout          ${PROXY_SEND_TIMEOUT};
+        proxy_read_timeout          ${PROXY_READ_TIMEOUT};
         proxy_pass http://model/;
         proxy_redirect off;
         proxy_http_version 1.1;

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,7 @@ else
 fi
 
 if [[ ! -e /etc/nginx/conf.d/default.nginx.conf ]];then
-    envsubst '$API_PORT $API_SERVER $UI_PORT $UI_PATH $BASE_URL' \
+    envsubst '$API_PORT $API_SERVER $UI_PORT $UI_PATH $BASE_URL $PROXY_CONNECT_TIMEOUT $PROXY_SEND_TIMEOUT $PROXY_READ_TIMEOUT' \
         < /etc/nginx/conf.d/default.nginx.conf.template \
         > /etc/nginx/conf.d/default.nginx.conf
 fi


### PR DESCRIPTION
Allow users to configure proxy timeouts via environment variables to support large clusters with longer query times. Defaults remain at 180s for backward compatibility.

New environment variables:
- PROXY_CONNECT_TIMEOUT (default: 180)
- PROXY_SEND_TIMEOUT (default: 180)
- PROXY_READ_TIMEOUT (default: 180)

Fixes #40

