### PR TITLE
feat: add custom aggregation options

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,15 @@ else
     sed -i "s^PLACEHOLDER_FOOTER_CONTENT^OpenCost version: $VERSION ($HEAD)^g" /var/www/*.js
 fi
 
+# Custom aggregation options: JSON object (map string:string), e.g. {"Label: team":"label:team"}
+if [[ ! -z "$CUSTOM_AGGREGATION_OPTIONS" ]]; then
+    echo "injecting CUSTOM_AGGREGATION_OPTIONS"
+    esc=$(printf '%s' "$CUSTOM_AGGREGATION_OPTIONS" | sed 's/\\/\\\\/g; s/&/\\&/g; s/"/\\"/g')
+    sed -i "s^PLACEHOLDER_CUSTOM_AGGREGATIONS^$esc^g" /var/www/*.js
+else
+    sed -i "s^PLACEHOLDER_CUSTOM_AGGREGATIONS^{}^g" /var/www/*.js
+fi
+
 if [[ ! -e /etc/nginx/conf.d/default.nginx.conf ]];then
     envsubst '$API_PORT $API_SERVER $UI_PORT $UI_PATH $BASE_URL $PROXY_CONNECT_TIMEOUT $PROXY_SEND_TIMEOUT $PROXY_READ_TIMEOUT' \
         < /etc/nginx/conf.d/default.nginx.conf.template \

--- a/src/pages/Allocations.js
+++ b/src/pages/Allocations.js
@@ -37,7 +37,7 @@ const windowOptions = [
   { name: "Last 14 days", value: "14d" },
 ];
 
-const aggregationOptions = [
+const baseAggregationOptions = [
   { name: "Cluster", value: "cluster" },
   { name: "Node", value: "node" },
   { name: "Namespace", value: "namespace" },
@@ -51,6 +51,34 @@ const aggregationOptions = [
   { name: "Pod", value: "pod" },
   { name: "Container", value: "container" },
 ];
+
+// Injected at runtime: entrypoint replaces the placeholder with env CUSTOM_AGGREGATION_OPTIONS (JSON map).
+// In local dev, set CUSTOM_AGGREGATION_OPTIONS to test (e.g. CUSTOM_AGGREGATION_OPTIONS='{"Label: team":"label:team"}' npm run serve).
+const customAggregationsJson =
+  (typeof process !== "undefined" && process.env?.CUSTOM_AGGREGATION_OPTIONS) ||
+  'PLACEHOLDER_CUSTOM_AGGREGATIONS';
+const aggregationOptions = (() => {
+  if (
+    !customAggregationsJson ||
+    customAggregationsJson.startsWith("PLACEHOLDER_") 
+  ) {
+    return baseAggregationOptions;
+  }
+  try {
+    const map = JSON.parse(customAggregationsJson);
+    const custom =
+      typeof map === "object" && map !== null && !Array.isArray(map)
+        ? Object.entries(map).map(([name, value]) => ({
+            name,
+            value: String(value),
+          }))
+        : [];
+    return [...baseAggregationOptions, ...custom];
+  } catch {
+    return baseAggregationOptions;
+  }
+})();
+
 
 const accumulateOptions = [
   { name: "Entire window", value: true },


### PR DESCRIPTION
## What does this PR change?
* This PR addresses the missing custom aggregation options feature in the UI. It implements a different but complementary approach compared to the expected solution by allowing users to add custom aggregation options through an environment variable, which can be also easily configured as a Helm chart value.

## Does this PR relate to any other PRs?
* N/A

## How will this PR impact users?
* No impact if not specifically configured

## Does this PR address any GitHub or Zendesk issues?
* https://github.com/opencost/opencost/issues/2528

## How was this PR tested?
* Tested locally with `npm run` and `docker run`, passing the `CUSTOM_AGGREGATION_OPTIONS` environment variable

## Does this PR require changes to documentation?
* Add example showing how to configure CUSTOM_AGGREGATION_OPTIONS in Helm values, Kubernetes manifest or local development

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?
* No, sorry, it's my first contribution. Please help me figure it out
