### PR TITLE
feat: add bar/line chart toggle to cost widgets

### DIFF
--- a/app/components/assets-visualization.tsx
+++ b/app/components/assets-visualization.tsx
@@ -9,8 +9,10 @@ import {
   Button,
   Loading,
 } from "@carbon/react";
-import { PieChart, SimpleBarChart } from "@carbon/charts-react";
+import { PieChart } from "@carbon/charts-react";
 import { ScaleTypes } from "@carbon/charts";
+import { SwitchableChart } from "./switchable-chart";
+import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
 import { Download } from "@carbon/icons-react";
 import "@carbon/charts-react/styles.css";
 import { type Asset } from "~/lib/assets-api";
@@ -38,6 +40,7 @@ function formatRamGb(ramBytes: number): string {
 
 export default function AssetsVisualization() {
   const [showFilters, setShowFilters] = useState(false);
+  const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [filterValues, setFilterValues] = useState<AssetsFilterValues>({
     window: DEFAULT_ASSETS_FILTERS.assetsWindow,
     aggregateBy: DEFAULT_ASSETS_FILTERS.assetsAggregateBy,
@@ -165,7 +168,7 @@ export default function AssetsVisualization() {
   }));
   const barChartData = sortedAssets
     .slice(0, 5)
-    .map((asset) => ({ group: asset.name, value: asset.totalCost }));
+    .map((asset) => ({ group: asset.name, key: "Cost", value: asset.totalCost }));
 
   const pieOptions = {
     title: "Cost by Asset Type",
@@ -294,6 +297,9 @@ export default function AssetsVisualization() {
         description="Infrastructure assets with cost and carbon tracking"
         expanded={showFilters}
         onToggle={() => setShowFilters((s) => !s)}
+        headerActions={
+          <ChartTypeToggle mode={chartMode} onChange={setChartMode} />
+        }
         filterContent={
           <AssetsFilterControls
             window={filterValues.window}
@@ -357,7 +363,12 @@ export default function AssetsVisualization() {
           <PieChart data={pieChartData} options={pieOptions} />
         </div>
         <div className="bg-[#f4f4f4] p-4 rounded">
-          <SimpleBarChart data={barChartData} options={barOptions} />
+          <SwitchableChart
+            data={barChartData}
+            options={barOptions}
+            mode={chartMode}
+            stacked={false}
+          />
         </div>
       </div>
 

--- a/app/components/chart-type-toggle.tsx
+++ b/app/components/chart-type-toggle.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@carbon/react";
+import { ChartColumn, ChartLineSmooth } from "@carbon/icons-react";
+
+export type ChartMode = "bar" | "line";
+
+interface ChartTypeToggleProps {
+  mode: ChartMode;
+  onChange: (mode: ChartMode) => void;
+}
+
+export function ChartTypeToggle({ mode, onChange }: ChartTypeToggleProps) {
+  return (
+    <div className="flex gap-1">
+      <Button
+        kind={mode === "bar" ? "primary" : "ghost"}
+        size="sm"
+        hasIconOnly
+        renderIcon={ChartColumn}
+        iconDescription="Bar chart"
+        onClick={() => onChange("bar")}
+      />
+      <Button
+        kind={mode === "line" ? "primary" : "ghost"}
+        size="sm"
+        hasIconOnly
+        renderIcon={ChartLineSmooth}
+        iconDescription="Line chart"
+        onClick={() => onChange("line")}
+      />
+    </div>
+  );
+}

--- a/app/components/cloud-cost-widget.tsx
+++ b/app/components/cloud-cost-widget.tsx
@@ -9,8 +9,9 @@ import {
   TableRow,
   Pagination,
 } from "@carbon/react";
-import { StackedBarChart } from "@carbon/charts-react";
 import { ScaleTypes } from "@carbon/charts";
+import { SwitchableChart } from "./switchable-chart";
+import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
 import CloudCostService from "~/services/cloud-cost";
 import {
   toCurrency,
@@ -150,6 +151,7 @@ export default function CloudCostWidget({
   currency: currencyProp,
 }: CloudCostWidgetProps) {
   const [showFilters, setShowFilters] = useState(false);
+  const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [localFilters, setLocalFilters] = useState({
     window: DEFAULT_CLOUD_FILTERS.cloudWindow,
     aggregateBy: DEFAULT_CLOUD_FILTERS.cloudAggregateBy,
@@ -308,6 +310,9 @@ export default function CloudCostWidget({
         description={title}
         expanded={showFilters}
         onToggle={() => setShowFilters((s) => !s)}
+        headerActions={
+          <ChartTypeToggle mode={chartMode} onChange={setChartMode} />
+        }
         filterContent={
           <CloudFilterControls
             window={window}
@@ -335,7 +340,12 @@ export default function CloudCostWidget({
           </div>
         ) : (
           <div className="w-full h-[300px]">
-            <StackedBarChart data={chartData} options={chartOptions} />
+            <SwitchableChart
+              data={chartData}
+              options={chartOptions}
+              mode={chartMode}
+              stacked
+            />
           </div>
         )}
       </div>

--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
-import { StackedBarChart } from "@carbon/charts-react";
 import { ScaleTypes } from "@carbon/charts";
+import { SwitchableChart } from "./switchable-chart";
+import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
 import AllocationService from "~/services/allocation";
 import {
   checkCustomWindow,
@@ -169,6 +170,7 @@ export default function CostAllocationChart({
   useSharedFilters = false,
 }: CostAllocationChartProps) {
   const [showFilters, setShowFilters] = useState(false);
+  const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [sharedFilters, setSharedFilters] =
     useAllocationFilters(useSharedFilters);
   const window = windowProp ?? sharedFilters.window;
@@ -304,6 +306,9 @@ export default function CostAllocationChart({
         description={description}
         expanded={showFilters}
         onToggle={() => setShowFilters((s) => !s)}
+        headerActions={
+          <ChartTypeToggle mode={chartMode} onChange={setChartMode} />
+        }
         filterContent={
           <AllocationFilterControls
             window={window}
@@ -326,7 +331,12 @@ export default function CostAllocationChart({
         </div>
       ) : (
         <div className="cost-allocation-chart w-full h-[400px] px-2">
-          <StackedBarChart data={chartData} options={chartOptions} />
+          <SwitchableChart
+            data={chartData}
+            options={chartOptions}
+            mode={chartMode}
+            stacked
+          />
         </div>
       )}
     </div>

--- a/app/components/external-services-chart-widget.tsx
+++ b/app/components/external-services-chart-widget.tsx
@@ -16,8 +16,9 @@ import {
   TableBody,
   TableCell,
 } from "@carbon/react";
-import { SimpleBarChart } from "@carbon/charts-react";
 import { ScaleTypes } from "@carbon/charts";
+import { SwitchableChart } from "./switchable-chart";
+import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
 import ExternalCostsService from "~/services/external-costs";
 import { toCurrency } from "~/lib/legacy-util";
 
@@ -96,6 +97,7 @@ export default function ExternalServicesChartWidget({
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
   const [tableData, setTableData] = useState<ExternalCostTableRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [selectedService, setSelectedService] = useState<string | null>(null);
 
   useEffect(() => {
@@ -148,13 +150,21 @@ export default function ExternalServicesChartWidget({
         </TabList>
         <TabPanels>
           <TabPanel>
-            <div className="w-full h-[400px] mt-4">
+            <div className="flex justify-end mt-2 mb-1">
+              <ChartTypeToggle mode={chartMode} onChange={setChartMode} />
+            </div>
+            <div className="w-full h-[400px]">
               {loading ? (
                 <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
                   Loading…
                 </div>
               ) : chartData.length > 0 ? (
-                <SimpleBarChart data={chartData} options={chartOptions} />
+                <SwitchableChart
+                  data={chartData}
+                  options={chartOptions}
+                  mode={chartMode}
+                  stacked={false}
+                />
               ) : (
                 <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
                   No external cost data available. Configure external cost

--- a/app/components/scoped-views.tsx
+++ b/app/components/scoped-views.tsx
@@ -116,6 +116,7 @@ export interface FilterableWidgetHeaderProps {
   expanded: boolean;
   onToggle: () => void;
   filterContent?: React.ReactNode;
+  headerActions?: React.ReactNode;
 }
 
 export function FilterableWidgetHeader({
@@ -124,6 +125,7 @@ export function FilterableWidgetHeader({
   expanded,
   onToggle,
   filterContent,
+  headerActions,
 }: FilterableWidgetHeaderProps) {
   return (
     <div className="mb-4">
@@ -134,15 +136,18 @@ export function FilterableWidgetHeader({
             <p className="text-sm text-[#525252] mt-1 mb-0">{description}</p>
           )}
         </div>
-        <Button
-          kind={expanded ? "primary" : "secondary"}
-          size="sm"
-          renderIcon={Filter}
-          iconDescription="Toggle filters"
-          onClick={onToggle}
-        >
-          {expanded ? "Collapse filters" : "Filters"}
-        </Button>
+        <div className="flex items-center gap-2">
+          {headerActions}
+          <Button
+            kind={expanded ? "primary" : "secondary"}
+            size="sm"
+            renderIcon={Filter}
+            iconDescription="Toggle filters"
+            onClick={onToggle}
+          >
+            {expanded ? "Collapse filters" : "Filters"}
+          </Button>
+        </div>
       </div>
       {expanded && filterContent && (
         <div className="mt-4 pt-4 border-t border-[#e0e0e0]">

--- a/app/components/switchable-chart.tsx
+++ b/app/components/switchable-chart.tsx
@@ -1,0 +1,43 @@
+import {
+  StackedBarChart,
+  SimpleBarChart,
+  LineChart,
+  StackedAreaChart,
+} from "@carbon/charts-react";
+import type { ChartMode } from "./chart-type-toggle";
+
+interface SwitchableChartProps {
+  data: { group: string; key: string; value: number }[];
+  options: Record<string, any>;
+  mode: ChartMode;
+  stacked?: boolean;
+}
+
+function buildLineOptions(options: Record<string, any>): Record<string, any> {
+  const { bars, ...rest } = options;
+  return {
+    ...rest,
+    curve: "curveMonotoneX",
+    points: { enabled: true, radius: 3 },
+  };
+}
+
+export function SwitchableChart({
+  data,
+  options,
+  mode,
+  stacked = true,
+}: SwitchableChartProps) {
+  if (mode === "line") {
+    const lineOptions = buildLineOptions(options);
+    if (stacked) {
+      return <StackedAreaChart data={data} options={lineOptions} />;
+    }
+    return <LineChart data={data} options={lineOptions} />;
+  }
+
+  if (stacked) {
+    return <StackedBarChart data={data} options={options} />;
+  }
+  return <SimpleBarChart data={data} options={options} />;
+}


### PR DESCRIPTION
## Summary

- Adds a toggle (bar chart / line chart icons) to all four cost visualization widgets, allowing users to switch between bar and line chart views
- Stacked bar charts (Cost Allocation, Cloud Cost) switch to stacked area charts in line mode for readability
- Non-stacked bar charts (External Services, Assets) switch to line charts
- No new dependencies — uses existing `LineChart` and `StackedAreaChart` from `@carbon/charts-react`

Closes #225

## New components

- **`ChartTypeToggle`** — reusable icon button pair using Carbon `ChartColumn` / `ChartLineSmooth` icons
- **`SwitchableChart`** — thin wrapper that renders the correct Carbon chart component based on mode + stacked props

## Modified components

- **`FilterableWidgetHeader`** — added optional `headerActions` slot for the toggle
- **`CostAllocationChart`** — bar/line toggle (stacked)
- **`CloudCostWidget`** — bar/line toggle (stacked)
- **`ExternalServicesChartWidget`** — bar/line toggle (non-stacked)
- **`AssetsVisualization`** — bar/line toggle (non-stacked)

## Test plan

- [ ] Verify bar chart renders by default on all four widgets (Cost Allocation, Cloud Cost, External Services, Assets)
- [ ] Click line chart icon — verify chart switches to line/area view with smooth curves and data points
- [ ] Click bar chart icon — verify chart switches back to bar view
- [ ] Verify tooltips work correctly in both modes
- [ ] Verify toggle state is independent per widget
- [ ] Verify no visual regressions on filter controls or other UI elements