### PR TITLE
feat: add Lighthouse CI for performance and accessibility auditing

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,0 +1,99 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        shell: bash
+        run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
+
+      - uses: actions/cache@v5
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        id: lighthouse
+        run: |
+          npm install -g @lhci/cli@0.14.x
+          lhci autorun --config=./lighthouserc.json || true
+
+      - name: Parse Lighthouse results
+        id: parse
+        if: always()
+        run: |
+          MANIFEST=".lighthouseci/manifest.json"
+
+          if [ ! -f "$MANIFEST" ]; then
+            echo "perf=N/A" >> "$GITHUB_OUTPUT"
+            echo "a11y=N/A" >> "$GITHUB_OUTPUT"
+            echo "bp=N/A" >> "$GITHUB_OUTPUT"
+            echo "seo=N/A" >> "$GITHUB_OUTPUT"
+            echo "report_url=Not available" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "perf=$(jq '[.[].summary.performance] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+          echo "a11y=$(jq '[.[].summary.accessibility] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+          echo "bp=$(jq '[.[].summary["best-practices"]] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+          echo "seo=$(jq '[.[].summary.seo] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+          echo "report_url=$(jq -r '.[0].links.publicUrl // "Not available"' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        if: github.event_name == 'pull_request' && always()
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          comment-tag: lighthouse-report
+          mode: recreate
+          message: |
+            ## Lighthouse Report
+
+            | Category | Score |
+            |----------|-------|
+            | Performance | **${{ steps.parse.outputs.perf }}** |
+            | Accessibility | **${{ steps.parse.outputs.a11y }}** |
+            | Best Practices | **${{ steps.parse.outputs.bp }}** |
+            | SEO | **${{ steps.parse.outputs.seo }}** |
+
+            [Full Report](${{ steps.parse.outputs.report_url }})
+
+      - name: Upload Lighthouse reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-reports
+          path: .lighthouseci/
+          retention-days: 30

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -45,12 +45,26 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify build output
+        run: |
+          echo "=== Build output ==="
+          ls -la build/client/
+          echo "=== Chrome location ==="
+          which google-chrome-stable || which google-chrome || which chromium-browser || echo "No Chrome found"
+          google-chrome-stable --version || google-chrome --version || chromium-browser --version || echo "Cannot get Chrome version"
+
       - name: Run Lighthouse CI
         id: lighthouse
         continue-on-error: true
         run: |
           npm install -g @lhci/cli@0.14.x
           lhci autorun --config=./lighthouserc.json
+
+      - name: Debug LHCI output
+        if: always()
+        run: |
+          echo "=== LHCI directory contents ==="
+          ls -laR .lighthouseci/ 2>/dev/null || echo ".lighthouseci/ does not exist"
 
       - name: Parse Lighthouse results
         id: parse

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,6 +15,7 @@ jobs:
 
     permissions:
       contents: read
+      issues: write
       pull-requests: write
 
     steps:

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -45,26 +45,10 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Verify build output
-        run: |
-          echo "=== Build output ==="
-          ls -la build/client/
-          echo "=== Chrome location ==="
-          which google-chrome-stable || which google-chrome || which chromium-browser || echo "No Chrome found"
-          google-chrome-stable --version || google-chrome --version || chromium-browser --version || echo "Cannot get Chrome version"
-
       - name: Run Lighthouse CI
         id: lighthouse
         continue-on-error: true
-        run: |
-          npm install -g @lhci/cli@0.14.x
-          lhci autorun --config=./lighthouserc.json
-
-      - name: Debug LHCI output
-        if: always()
-        run: |
-          echo "=== LHCI directory contents ==="
-          ls -laR .lighthouseci/ 2>/dev/null || echo ".lighthouseci/ does not exist"
+        run: npx -y @lhci/cli@0.14.x autorun --config=./lighthouserc.json 2>&1 | tee lhci-output.log
 
       - name: Parse Lighthouse results
         id: parse
@@ -78,6 +62,29 @@ jobs:
             echo "bp=N/A" >> "$GITHUB_OUTPUT"
             echo "seo=N/A" >> "$GITHUB_OUTPUT"
             echo "report_url=Not available" >> "$GITHUB_OUTPUT"
+            # Include LHCI log in output for debugging
+            LOG_CONTENT=""
+            if [ -f "lhci-output.log" ]; then
+              LOG_CONTENT=$(tail -30 lhci-output.log)
+            fi
+            EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64)
+            {
+              echo "debug_info<<${EOF_MARKER}"
+              echo "<details><summary>LHCI Debug Log</summary>"
+              echo ""
+              echo '```'
+              echo "=== Build output ==="
+              ls build/client/ 2>/dev/null || echo "build/client/ not found"
+              echo ""
+              echo "=== LHCI output ==="
+              echo "$LOG_CONTENT"
+              echo ""
+              echo "=== .lighthouseci/ contents ==="
+              ls -la .lighthouseci/ 2>/dev/null || echo ".lighthouseci/ not found"
+              echo '```'
+              echo "</details>"
+              echo "${EOF_MARKER}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -104,6 +111,8 @@ jobs:
             | SEO | **${{ steps.parse.outputs.seo }}** |
 
             [Full Report](${{ steps.parse.outputs.report_url }})
+
+            ${{ steps.parse.outputs.debug_info }}
 
       - name: Upload Lighthouse reports
         if: always()

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -74,7 +74,8 @@ jobs:
 
           # Get report URL from links.json
           if [ -f "$LHCI_DIR/links.json" ]; then
-            echo "report_url=$(jq -r 'to_entries[0].value // "Not available"' "$LHCI_DIR/links.json")" >> "$GITHUB_OUTPUT"
+            report_url=$(jq -r 'to_entries[0].value // "Not available"' "$LHCI_DIR/links.json")
+            echo "report_url=$report_url" >> "$GITHUB_OUTPUT"
           else
             echo "report_url=Not available" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -47,9 +47,10 @@ jobs:
 
       - name: Run Lighthouse CI
         id: lighthouse
+        continue-on-error: true
         run: |
           npm install -g @lhci/cli@0.14.x
-          lhci autorun --config=./lighthouserc.json || true
+          lhci autorun --config=./lighthouserc.json
 
       - name: Parse Lighthouse results
         id: parse
@@ -96,4 +97,5 @@ jobs:
         with:
           name: lighthouse-reports
           path: .lighthouseci/
+          if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -48,51 +48,36 @@ jobs:
       - name: Run Lighthouse CI
         id: lighthouse
         continue-on-error: true
-        run: npx -y @lhci/cli@0.14.x autorun --config=./lighthouserc.json 2>&1 | tee lhci-output.log
+        run: npx -y @lhci/cli@0.14.x autorun --config=./lighthouserc.json
 
       - name: Parse Lighthouse results
         id: parse
         if: always()
         run: |
-          MANIFEST=".lighthouseci/manifest.json"
+          LHCI_DIR=".lighthouseci"
 
-          if [ ! -f "$MANIFEST" ]; then
+          # Check if any LHR JSON files exist
+          if ! ls "$LHCI_DIR"/lhr-*.json 1>/dev/null 2>&1; then
             echo "perf=N/A" >> "$GITHUB_OUTPUT"
             echo "a11y=N/A" >> "$GITHUB_OUTPUT"
             echo "bp=N/A" >> "$GITHUB_OUTPUT"
             echo "seo=N/A" >> "$GITHUB_OUTPUT"
             echo "report_url=Not available" >> "$GITHUB_OUTPUT"
-            # Include LHCI log in output for debugging
-            LOG_CONTENT=""
-            if [ -f "lhci-output.log" ]; then
-              LOG_CONTENT=$(tail -30 lhci-output.log)
-            fi
-            EOF_MARKER=$(dd if=/dev/urandom bs=15 count=1 2>/dev/null | base64)
-            {
-              echo "debug_info<<${EOF_MARKER}"
-              echo "<details><summary>LHCI Debug Log</summary>"
-              echo ""
-              echo '```'
-              echo "=== Build output ==="
-              ls build/client/ 2>/dev/null || echo "build/client/ not found"
-              echo ""
-              echo "=== LHCI output ==="
-              echo "$LOG_CONTENT"
-              echo ""
-              echo "=== .lighthouseci/ contents ==="
-              ls -la .lighthouseci/ 2>/dev/null || echo ".lighthouseci/ not found"
-              echo '```'
-              echo "</details>"
-              echo "${EOF_MARKER}"
-            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "perf=$(jq '[.[].summary.performance] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
-          echo "a11y=$(jq '[.[].summary.accessibility] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
-          echo "bp=$(jq '[.[].summary["best-practices"]] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
-          echo "seo=$(jq '[.[].summary.seo] | (add / length * 100) | floor' "$MANIFEST")" >> "$GITHUB_OUTPUT"
-          echo "report_url=$(jq -r '.[0].links.publicUrl // "Not available"' "$MANIFEST")" >> "$GITHUB_OUTPUT"
+          # Parse average scores from all LHR JSON files
+          echo "perf=$(jq -s '[.[].categories.performance.score] | (add / length * 100) | floor' "$LHCI_DIR"/lhr-*.json)" >> "$GITHUB_OUTPUT"
+          echo "a11y=$(jq -s '[.[].categories.accessibility.score] | (add / length * 100) | floor' "$LHCI_DIR"/lhr-*.json)" >> "$GITHUB_OUTPUT"
+          echo "bp=$(jq -s '[.[].categories["best-practices"].score] | (add / length * 100) | floor' "$LHCI_DIR"/lhr-*.json)" >> "$GITHUB_OUTPUT"
+          echo "seo=$(jq -s '[.[].categories.seo.score] | (add / length * 100) | floor' "$LHCI_DIR"/lhr-*.json)" >> "$GITHUB_OUTPUT"
+
+          # Get report URL from links.json
+          if [ -f "$LHCI_DIR/links.json" ]; then
+            echo "report_url=$(jq -r 'to_entries[0].value // "Not available"' "$LHCI_DIR/links.json")" >> "$GITHUB_OUTPUT"
+          else
+            echo "report_url=Not available" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
@@ -111,8 +96,6 @@ jobs:
             | SEO | **${{ steps.parse.outputs.seo }}** |
 
             [Full Report](${{ steps.parse.outputs.report_url }})
-
-            ${{ steps.parse.outputs.debug_info }}
 
       - name: Upload Lighthouse reports
         if: always()

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ tilt_config.json
 /.react-router/
 /build/
 
+# Lighthouse CI
+.lighthouseci/
+

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -25,8 +25,7 @@
       }
     },
     "upload": {
-      "target": "filesystem",
-      "outputDir": "./lhci_reports"
+      "target": "temporary-public-storage"
     }
   }
 }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -25,7 +25,8 @@
       }
     },
     "upload": {
-      "target": "temporary-public-storage"
+      "target": "filesystem",
+      "outputDir": "./lhci_reports"
     }
   }
 }

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,11 +1,13 @@
 {
   "ci": {
     "collect": {
-      "staticDistDir": "./build/client",
+      "startServerCommand": "npx serve build/client -s -l 8080",
+      "startServerReadyPattern": "Accepting connections",
+      "url": ["http://localhost:8080/"],
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop",
-        "chromeFlags": ["--no-sandbox"],
+        "chromeFlags": ["--no-sandbox", "--disable-gpu", "--headless=new"],
         "onlyCategories": [
           "performance",
           "accessibility",

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,28 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./build/client",
+      "numberOfRuns": 3,
+      "settings": {
+        "preset": "desktop",
+        "onlyCategories": [
+          "performance",
+          "accessibility",
+          "best-practices",
+          "seo"
+        ]
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["warn", { "minScore": 0.8 }],
+        "categories:accessibility": ["warn", { "minScore": 0.8 }],
+        "categories:best-practices": ["warn", { "minScore": 0.8 }],
+        "categories:seo": ["warn", { "minScore": 0.8 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -5,6 +5,7 @@
       "numberOfRuns": 3,
       "settings": {
         "preset": "desktop",
+        "chromeFlags": ["--no-sandbox"],
         "onlyCategories": [
           "performance",
           "accessibility",


### PR DESCRIPTION
## Summary
- Adds a Lighthouse CI GitHub Actions workflow that runs on PRs and pushes to `main`, auditing performance, accessibility, best practices, and SEO
- Posts a score summary table as a PR comment and uploads full reports as artifacts
- Configures score thresholds at `warn` level (80%) to surface regressions without blocking PRs

## Details

**Workflow** (`.github/workflows/lighthouse-ci.yml`):
- Matches existing CI patterns (Node via `.nvmrc`, npm caching)
- Builds the standard UI with `npm run build`, then runs 3 Lighthouse audits against `build/client/`
- Parses scores from the LHCI manifest and comments on the PR with a summary table
- Uses `recreate` mode so the comment is updated on new pushes rather than duplicated
- Uploads `.lighthouseci/` as artifacts with 30-day retention

**Configuration** (`lighthouserc.json`):
- Desktop preset, 3 runs averaged
- Categories: performance, accessibility, best practices, SEO
- All thresholds set to `warn` at 0.8 — can be tightened once a baseline is established
- Results uploaded to temporary public storage for shareable report links

**Note on prior attempt**: PR #220 was closed unmerged because `staticDistDir` pointed at `./dist` instead of `./build/client/`, causing Lighthouse to find no content to audit. This PR fixes that and simplifies the build step.

Closes #219

## Test plan
- [ ] Verify the workflow triggers on a PR to `main`
- [ ] Confirm Lighthouse scores appear as a PR comment
- [ ] Confirm report artifacts are uploaded
- [ ] Check that the "Full Report" link in the comment is accessible
