### PR TITLE
Fix CVE-2026-22184: upgrade Alpine packages to patch zlib vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN test -f /opt/standard/index.html && test -f /opt/ui/build/client/index.html 
 
 FROM nginx:alpine
 
+RUN apk update && apk upgrade --no-cache
+
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN test -f /opt/standard/index.html && test -f /opt/ui/build/client/index.html 
 
 FROM nginx:alpine
 
-RUN apk update && apk upgrade --no-cache
+RUN apk --no-cache upgrade
 
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,5 +1,7 @@
 FROM nginx:alpine
 
+RUN apk update && apk upgrade --no-cache
+
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile.cross
+++ b/Dockerfile.cross
@@ -1,6 +1,6 @@
 FROM nginx:alpine
 
-RUN apk update && apk upgrade --no-cache
+RUN apk --no-cache upgrade
 
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -3,6 +3,8 @@
 # Tilt cannot reference files that exist outside of this ./ui folder so the reference to THIRD_PARTY_LICENSES.txt is removed
 FROM nginx:alpine
 
+RUN apk update && apk upgrade --no-cache
+
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/
 LABEL org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -3,7 +3,7 @@
 # Tilt cannot reference files that exist outside of this ./ui folder so the reference to THIRD_PARTY_LICENSES.txt is removed
 FROM nginx:alpine
 
-RUN apk update && apk upgrade --no-cache
+RUN apk --no-cache upgrade
 
 LABEL org.opencontainers.image.description="Cross-cloud cost allocation models for Kubernetes workloads"
 LABEL org.opencontainers.image.documentation=https://opencost.io/docs/


### PR DESCRIPTION
## Summary

- Adds `apk --no-cache upgrade` to all three Dockerfiles (`Dockerfile`, `Dockerfile.cross`, `Dockerfile.debug`) to ensure base image packages are updated during build
- This patches CVE-2026-22184, a critical global buffer overflow in zlib's untgz utility (`TGZfname()` function) that can lead to memory corruption, denial of service, or arbitrary code execution when an archive name exceeds 1024 bytes
- Uses `--no-cache` to avoid leaving cached repository indexes in the image layer

Fixes #224

## Test plan

- [ ] Build each Dockerfile and verify the `apk upgrade` step completes successfully
- [ ] Run `docker run --rm <image> apk info zlib` to confirm the installed zlib version includes the CVE fix
- [ ] Scan the resulting images with a vulnerability scanner (e.g. Trivy, Grype) to confirm CVE-2026-22184 is no longer reported
- [ ] Verify nginx starts and serves the UI correctly from the built image