### PR TITLE
feat(theme): add dark mode with Carbon white/g100 themes (#240)

### DIFF
--- a/app/app.scss
+++ b/app/app.scss
@@ -15,8 +15,6 @@
 }
 
 body {
-  background-color: var(--cds-background);
-  color: var(--cds-text-primary);
   font-family:
     "IBM Plex Sans",
     -apple-system,
@@ -25,6 +23,14 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+// Only tokenize body surface colors when the new UI has applied a theme
+// attribute via the bootstrap script — legacy builds never set this and
+// therefore keep their previous (browser default) body background/colors.
+html[data-carbon-theme] body {
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
 }
 
 .dashboard-grid {

--- a/app/app.scss
+++ b/app/app.scss
@@ -1,6 +1,22 @@
+@use "@carbon/react/scss/theme";
+@use "@carbon/react/scss/themes";
 @use "@carbon/react";
 
+:root,
+.cds--white {
+  @include theme.theme(themes.$white);
+  color-scheme: light;
+}
+
+[data-carbon-theme="g100"],
+.cds--g100 {
+  @include theme.theme(themes.$g100);
+  color-scheme: dark;
+}
+
 body {
+  background-color: var(--cds-background);
+  color: var(--cds-text-primary);
   font-family:
     "IBM Plex Sans",
     -apple-system,
@@ -32,8 +48,8 @@ body {
 }
 
 .card-enhanced {
-  background: white;
-  border: 1px solid #e0e0e0;
+  background: var(--cds-layer);
+  border: 1px solid var(--cds-border-subtle);
   border-radius: 4px;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.12),
@@ -45,27 +61,27 @@ body {
   box-shadow:
     0 4px 8px rgba(0, 0, 0, 0.15),
     0 2px 4px rgba(0, 0, 0, 0.1);
-  border-color: #0f62fe;
+  border-color: var(--cds-focus);
 }
 
 .section-title {
   font-size: 1.125rem;
   font-weight: 600;
-  color: #161616;
+  color: var(--cds-text-primary);
   margin-bottom: 0.5rem;
   letter-spacing: -0.01em;
 }
 
 .section-description {
   font-size: 0.875rem;
-  color: #525252;
+  color: var(--cds-text-secondary);
   margin-bottom: 1rem;
   line-height: 1.5;
 }
 
 .metric-card {
-  background: white;
-  border: 1px solid #e0e0e0;
+  background: var(--cds-layer);
+  border: 1px solid var(--cds-border-subtle);
   border-radius: 4px;
   padding: 1.25rem;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
@@ -79,14 +95,14 @@ body {
 .metric-value {
   font-size: 1.75rem;
   font-weight: 700;
-  color: #161616;
+  color: var(--cds-text-primary);
   line-height: 1.2;
   letter-spacing: -0.02em;
 }
 
 .metric-label {
   font-size: 0.875rem;
-  color: #525252;
+  color: var(--cds-text-secondary);
   font-weight: 500;
   margin-bottom: 0.75rem;
   letter-spacing: -0.01em;
@@ -99,8 +115,8 @@ body {
 }
 
 .section-card {
-  background: white;
-  border: 1px solid #e0e0e0;
+  background: var(--cds-layer);
+  border: 1px solid var(--cds-border-subtle);
   border-radius: 4px;
   padding: 1.5rem;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
@@ -108,12 +124,12 @@ body {
 }
 
 .legacy-banner {
-  background: #fff8e1;
-  border-left: 4px solid #f59e0b;
+  background: var(--cds-notification-background-warning, #fff8e1);
+  border-left: 4px solid var(--cds-support-warning, #f59e0b);
   padding: 0.75rem 1rem;
   margin-bottom: 1.5rem;
   font-size: 0.875rem;
-  color: #525252;
+  color: var(--cds-text-secondary);
 }
 
 .cost-allocation-chart {

--- a/app/components/app-header.tsx
+++ b/app/components/app-header.tsx
@@ -1,0 +1,36 @@
+import {
+  Header,
+  HeaderGlobalAction,
+  HeaderGlobalBar,
+  HeaderName,
+} from "@carbon/react";
+import { Asleep, Light } from "@carbon/icons-react";
+import { useAppTheme } from "~/components/theme-context";
+
+interface AppHeaderProps {
+  children?: React.ReactNode;
+}
+
+export default function AppHeader({ children }: AppHeaderProps) {
+  const { theme, toggleTheme } = useAppTheme();
+  const isDark = theme === "g100";
+
+  return (
+    <Header aria-label="OpenCost Platform">
+      <HeaderName href="/" prefix="">
+        <img src="/logo.png" alt="OpenCost" className="h-6" />
+      </HeaderName>
+      <HeaderGlobalBar>
+        {children}
+        <HeaderGlobalAction
+          aria-label={isDark ? "Switch to light theme" : "Switch to dark theme"}
+          aria-pressed={isDark}
+          tooltipAlignment="end"
+          onClick={toggleTheme}
+        >
+          {isDark ? <Light size={20} /> : <Asleep size={20} />}
+        </HeaderGlobalAction>
+      </HeaderGlobalBar>
+    </Header>
+  );
+}

--- a/app/components/app-mui-theme-bridge.tsx
+++ b/app/components/app-mui-theme-bridge.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+import { ThemeProvider as MuiThemeProvider, createTheme } from "@mui/material";
+import { useAppTheme } from "~/components/theme-context";
+
+export default function AppMuiThemeBridge({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { theme } = useAppTheme();
+
+  const muiTheme = useMemo(
+    () =>
+      createTheme({
+        palette: {
+          mode: theme === "g100" ? "dark" : "light",
+        },
+      }),
+    [theme],
+  );
+
+  return <MuiThemeProvider theme={muiTheme}>{children}</MuiThemeProvider>;
+}

--- a/app/components/assets-visualization.tsx
+++ b/app/components/assets-visualization.tsx
@@ -334,7 +334,7 @@ export default function AssetsVisualization() {
       />
 
       {error && (
-        <div className="p-3 bg-[var(--cds-support-warning)] text-[var(--cds-text-inverse)] rounded mb-4 text-sm">
+        <div className="p-3 bg-[var(--cds-notification-background-warning)] text-[var(--cds-text-primary)] border-l-4 border-[var(--cds-support-warning)] rounded mb-4 text-sm">
           ⚠️ {error}
         </div>
       )}

--- a/app/components/assets-visualization.tsx
+++ b/app/components/assets-visualization.tsx
@@ -17,6 +17,7 @@ import { Download } from "@carbon/icons-react";
 import "@carbon/charts-react/styles.css";
 import { type Asset } from "~/lib/assets-api";
 import AssetsService from "~/services/assets";
+import { useAppTheme } from "~/components/theme-context";
 import {
   AssetsFilterControls,
   DEFAULT_ASSETS_FILTERS,
@@ -54,6 +55,7 @@ export default function AssetsVisualization() {
   const [assets, setAssets] = useState<Asset[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { theme } = useAppTheme();
 
   useEffect(() => {
     let cancelled = false;
@@ -170,22 +172,30 @@ export default function AssetsVisualization() {
     .slice(0, 5)
     .map((asset) => ({ group: asset.name, key: "Cost", value: asset.totalCost }));
 
-  const pieOptions = {
-    title: "Cost by Asset Type",
-    resizable: true,
-    height: "300px",
-    pie: { alignment: "center" as const },
-    legend: { alignment: "center" as const },
-  };
+  const pieOptions = useMemo(
+    () => ({
+      theme,
+      title: "Cost by Asset Type",
+      resizable: true,
+      height: "300px",
+      pie: { alignment: "center" as const },
+      legend: { alignment: "center" as const },
+    }),
+    [theme],
+  );
 
-  const barOptions = {
-    title: "Top 5 Assets by Cost",
-    axes: {
-      left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
-      bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
-    },
-    height: "300px",
-  };
+  const barOptions = useMemo(
+    () => ({
+      theme,
+      title: "Top 5 Assets by Cost",
+      axes: {
+        left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
+        bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
+      },
+      height: "300px",
+    }),
+    [theme],
+  );
 
   if (isLoading) {
     return (
@@ -196,7 +206,7 @@ export default function AssetsVisualization() {
   }
 
   const AssetRow = ({ asset }: { asset: Asset }) => (
-    <div className="p-3 rounded border border-[#e0e0e0] mb-2 hover:bg-[#f4f4f4] transition-colors">
+    <div className="p-3 rounded border border-[var(--cds-border-subtle)] mb-2 hover:bg-[var(--cds-layer-hover)] transition-colors">
       <div className="flex items-start justify-between">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-1 flex-wrap">
@@ -212,7 +222,7 @@ export default function AssetsVisualization() {
               </Tag>
             )}
           </div>
-          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[#8d8d8d]">
+          <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-[var(--cds-text-placeholder)]">
             {asset.ip && <span title="Internal / node IP">{asset.ip}</span>}
             <span>{asset.cluster}</span>
             <span>{asset.region}</span>
@@ -236,7 +246,7 @@ export default function AssetsVisualization() {
           <div className="font-semibold text-sm">
             ${asset.totalCost.toFixed(2)}
           </div>
-          <div className="text-xs text-[#8d8d8d]">
+          <div className="text-xs text-[var(--cds-text-placeholder)]">
             {asset.carbonEmissions.toFixed(2)} kg CO₂e
           </div>
         </div>
@@ -324,7 +334,7 @@ export default function AssetsVisualization() {
       />
 
       {error && (
-        <div className="p-3 bg-[#f1c21b] text-black rounded mb-4 text-sm">
+        <div className="p-3 bg-[var(--cds-support-warning)] text-[var(--cds-text-inverse)] rounded mb-4 text-sm">
           ⚠️ {error}
         </div>
       )}
@@ -333,36 +343,36 @@ export default function AssetsVisualization() {
         <div className="metric-card">
           <div className="metric-label">Total Assets</div>
           <div className="metric-value">{assets.length}</div>
-          <p className="metric-change text-[#525252]">
+          <p className="metric-change text-[var(--cds-text-secondary)]">
             {typeData.length} types
           </p>
         </div>
         <div className="metric-card">
           <div className="metric-label">Total Cost</div>
           <div className="metric-value">${totalCost.toFixed(2)}</div>
-          <p className="metric-change text-[#525252]">This period</p>
+          <p className="metric-change text-[var(--cds-text-secondary)]">This period</p>
         </div>
         <div className="metric-card">
           <div className="metric-label">Carbon Emissions</div>
           <div className="metric-value">{totalCarbon.toFixed(2)} kg CO₂e</div>
-          <p className="metric-change text-[#525252]">Environmental impact</p>
+          <p className="metric-change text-[var(--cds-text-secondary)]">Environmental impact</p>
         </div>
         <div className="metric-card">
           <div className="metric-label">Avg Utilization</div>
           <div className="metric-value">
             {avgUtilization === null ? "—" : `${avgUtilization}%`}
           </div>
-          <p className="metric-change text-[#525252]">
+          <p className="metric-change text-[var(--cds-text-secondary)]">
             CPU + Memory (where reported)
           </p>
         </div>
       </div>
 
       <div className="grid grid-cols-2 gap-4 mb-6">
-        <div className="bg-[#f4f4f4] p-4 rounded">
+        <div className="bg-[var(--cds-layer-accent)] p-4 rounded">
           <PieChart data={pieChartData} options={pieOptions} />
         </div>
-        <div className="bg-[#f4f4f4] p-4 rounded">
+        <div className="bg-[var(--cds-layer-accent)] p-4 rounded">
           <SwitchableChart
             data={barChartData}
             options={barOptions}
@@ -373,12 +383,12 @@ export default function AssetsVisualization() {
       </div>
 
       <div>
-        <div className="flex items-center justify-between mb-4 pb-4 border-b border-[#e0e0e0]">
+        <div className="flex items-center justify-between mb-4 pb-4 border-b border-[var(--cds-border-subtle)]">
           <div>
-            <h4 className="text-base font-semibold text-[#161616]">
+            <h4 className="text-base font-semibold text-[var(--cds-text-primary)]">
               All Assets
             </h4>
-            <p className="text-sm text-[#525252]">
+            <p className="text-sm text-[var(--cds-text-secondary)]">
               View and manage infrastructure resources
             </p>
           </div>

--- a/app/components/assets-visualization.tsx
+++ b/app/components/assets-visualization.tsx
@@ -172,30 +172,24 @@ export default function AssetsVisualization() {
     .slice(0, 5)
     .map((asset) => ({ group: asset.name, key: "Cost", value: asset.totalCost }));
 
-  const pieOptions = useMemo(
-    () => ({
-      theme,
-      title: "Cost by Asset Type",
-      resizable: true,
-      height: "300px",
-      pie: { alignment: "center" as const },
-      legend: { alignment: "center" as const },
-    }),
-    [theme],
-  );
+  const pieOptions = {
+    theme,
+    title: "Cost by Asset Type",
+    resizable: true,
+    height: "300px",
+    pie: { alignment: "center" as const },
+    legend: { alignment: "center" as const },
+  };
 
-  const barOptions = useMemo(
-    () => ({
-      theme,
-      title: "Top 5 Assets by Cost",
-      axes: {
-        left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
-        bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
-      },
-      height: "300px",
-    }),
-    [theme],
-  );
+  const barOptions = {
+    theme,
+    title: "Top 5 Assets by Cost",
+    axes: {
+      left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
+      bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
+    },
+    height: "300px",
+  };
 
   if (isLoading) {
     return (

--- a/app/components/cloud-cost-table-widget.tsx
+++ b/app/components/cloud-cost-table-widget.tsx
@@ -162,9 +162,9 @@ export default function CloudCostTableWidget({
         }
       />
       {loading ? (
-        <div className="p-8 text-center text-[#8d8d8d]">Loading...</div>
+        <div className="p-8 text-center text-[var(--cds-text-placeholder)]">Loading...</div>
       ) : rows.length === 0 ? (
-        <div className="p-8 text-center text-[#8d8d8d]">
+        <div className="p-8 text-center text-[var(--cds-text-placeholder)]">
           No cloud cost data available.
         </div>
       ) : (

--- a/app/components/cloud-cost-widget.tsx
+++ b/app/components/cloud-cost-widget.tsx
@@ -12,6 +12,7 @@ import {
 import { ScaleTypes } from "@carbon/charts";
 import { SwitchableChart } from "./switchable-chart";
 import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
+import { useAppTheme } from "~/components/theme-context";
 import CloudCostService from "~/services/cloud-cost";
 import {
   toCurrency,
@@ -166,6 +167,7 @@ export default function CloudCostWidget({
   const [tableRows, setTableRows] = useState<CloudCostRow[]>([]);
   const [tableTotal, setTableTotal] = useState<CloudCostRow | null>(null);
   const [loading, setLoading] = useState(true);
+  const { theme } = useAppTheme();
   const [page, setPage] = useState(1);
   const [pageSize, setPageSize] = useState(25);
   const [sortConfig, setSortConfig] = useState<{
@@ -250,6 +252,7 @@ export default function CloudCostWidget({
   const chartOptions = useMemo(() => {
     const colorScale = buildColorScale(chartData);
     return {
+      theme,
       title: "",
       axes: {
         left: {
@@ -293,11 +296,11 @@ export default function CloudCostWidget({
               return `<p style="margin:0 0 4px 0;font-size:0.875rem;display:flex;align-items:center;gap:6px"><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${fill};flex-shrink:0"></span><span>${String(name)}: ${toCurrency(val, currency)}</span></p>`;
             })
             .join("");
-          return `<div style="padding:8px 12px">${lines}<p style="margin:8px 0 0 0;font-size:0.875rem;font-weight:600;border-top:1px solid #e0e0e0;padding-top:6px">Total: ${toCurrency(total, currency)}</p></div>`;
+          return `<div style="padding:8px 12px">${lines}<p style="margin:8px 0 0 0;font-size:0.875rem;font-weight:600;border-top:1px solid var(--cds-border-subtle);padding-top:6px">Total: ${toCurrency(total, currency)}</p></div>`;
         },
       },
     };
-  }, [chartData, currency]);
+  }, [chartData, currency, theme]);
 
   const setFilter = (key: keyof typeof localFilters, value: string) => {
     setLocalFilters((prev) => ({ ...prev, [key]: value }));
@@ -331,11 +334,11 @@ export default function CloudCostWidget({
       {/* Chart */}
       <div id="cloud-graph" className="mb-6">
         {loading ? (
-          <div className="h-[300px] flex items-center justify-center text-[#8d8d8d]">
+          <div className="h-[300px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
             Loading…
           </div>
         ) : chartData.length === 0 ? (
-          <div className="h-[300px] flex items-center justify-center text-[#8d8d8d]">
+          <div className="h-[300px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
             No cloud cost data available.
           </div>
         ) : (
@@ -353,9 +356,9 @@ export default function CloudCostWidget({
       {/* Table */}
       <div id="cloud-cost-table">
         {loading ? (
-          <div className="p-8 text-center text-[#8d8d8d]">Loading…</div>
+          <div className="p-8 text-center text-[var(--cds-text-placeholder)]">Loading…</div>
         ) : tableRows.length === 0 ? (
-          <div className="p-8 text-center text-[#8d8d8d]">No results</div>
+          <div className="p-8 text-center text-[var(--cds-text-placeholder)]">No results</div>
         ) : (
           <>
             <TableContainer>
@@ -407,7 +410,7 @@ export default function CloudCostWidget({
                       key={`${row.name ?? row.labelName ?? "row"}-${startIndex + index}`}
                     >
                       <TableCell>
-                        <span className="text-[#0f62fe] cursor-pointer">
+                        <span className="text-[var(--cds-link-primary)] cursor-pointer">
                           {String(row.labelName ?? row.name ?? "")}
                         </span>
                       </TableCell>

--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useMemo } from "react";
+import { useAppTheme } from "~/components/theme-context";
 import { ScaleTypes } from "@carbon/charts";
 import { SwitchableChart } from "./switchable-chart";
 import { ChartTypeToggle, type ChartMode } from "./chart-type-toggle";
@@ -187,6 +188,7 @@ export default function CostAllocationChart({
 
   const [rawData, setRawData] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const { theme } = useAppTheme();
 
   const chartTitle = generateTitle(window, aggregateBy, accumulate);
   const chartData = useMemo(
@@ -234,6 +236,7 @@ export default function CostAllocationChart({
   const chartOptions = useMemo(() => {
     const colorScale = buildColorScale(chartData);
     return {
+      theme,
       title: chartTitle,
       axes: {
         left: {
@@ -281,11 +284,11 @@ export default function CostAllocationChart({
               return `<p style="margin:0 0 4px 0;font-size:0.875rem;display:flex;align-items:center;gap:6px"><span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${fill};flex-shrink:0"></span><span>${String(name)}: ${toCurrency(val, currency)}</span></p>`;
             })
             .join("");
-          return `<div style="padding:8px 12px">${lines}<p style="margin:8px 0 0 0;font-size:0.875rem;font-weight:600;border-top:1px solid #e0e0e0;padding-top:6px">Total: ${toCurrency(total, currency)}</p></div>`;
+          return `<div style="padding:8px 12px">${lines}<p style="margin:8px 0 0 0;font-size:0.875rem;font-weight:600;border-top:1px solid var(--cds-border-subtle);padding-top:6px">Total: ${toCurrency(total, currency)}</p></div>`;
         },
       },
     };
-  }, [chartTitle, chartData, currency]);
+  }, [chartTitle, chartData, currency, theme]);
 
   const setFilter = (
     key: keyof typeof sharedFilters,
@@ -326,7 +329,7 @@ export default function CostAllocationChart({
         }
       />
       {loading ? (
-        <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
+        <div className="h-[400px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
           Loading…
         </div>
       ) : (

--- a/app/components/cost-allocation-table.tsx
+++ b/app/components/cost-allocation-table.tsx
@@ -331,13 +331,13 @@ export default function CostAllocationTable({
   });
 
   if (loading) {
-    return <div className="p-8 text-center text-[#8d8d8d]">Loading…</div>;
+    return <div className="p-8 text-center text-[var(--cds-text-placeholder)]">Loading…</div>;
   }
 
   if (allocationData.length === 0) {
     return (
       <div className="w-full">
-        <p className="p-8 text-center text-[#8d8d8d]">
+        <p className="p-8 text-center text-[var(--cds-text-placeholder)]">
           No allocation data available.
         </p>
       </div>
@@ -362,7 +362,7 @@ export default function CostAllocationTable({
         <div className="mb-4">
           <h3 className="text-lg font-semibold m-0">{title}</h3>
           {description && (
-            <p className="text-sm text-[#525252] mt-1 mb-0">{description}</p>
+            <p className="text-sm text-[var(--cds-text-secondary)] mt-1 mb-0">{description}</p>
           )}
         </div>
       ) : (
@@ -391,13 +391,13 @@ export default function CostAllocationTable({
       <div className="flex flex-wrap gap-4 items-end mb-4">
         {drilldownFilters.length > 0 && (
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm text-[#525252]">Filters:</span>
+            <span className="text-sm text-[var(--cds-text-secondary)]">Filters:</span>
             {drilldownFilters.map((f, i) => (
               <button
                 key={i}
                 type="button"
                 onClick={() => handleBreadcrumb(i)}
-                className="text-xs px-2 py-[2px] rounded border border-[#e0e0e0] bg-[#f4f4f4] cursor-pointer inline-flex items-center gap-1"
+                className="text-xs px-2 py-[2px] rounded border border-[var(--cds-border-subtle)] bg-[var(--cds-layer-accent)] cursor-pointer inline-flex items-center gap-1"
                 aria-label={`Remove filter ${f.property}: ${f.value}`}
               >
                 <span>
@@ -409,7 +409,7 @@ export default function CostAllocationTable({
             <button
               type="button"
               onClick={() => handleBreadcrumb(-1)}
-              className="text-xs text-[#0f62fe] bg-transparent border-none cursor-pointer"
+              className="text-xs text-[var(--cds-link-primary)] bg-transparent border-none cursor-pointer"
             >
               Clear all
             </button>

--- a/app/components/cost-by-service-chart.tsx
+++ b/app/components/cost-by-service-chart.tsx
@@ -5,6 +5,7 @@ import { Loading } from "@carbon/react";
 import CloudCostService from "~/services/cloud-cost";
 import { primary, greyscale, browns } from "~/constants/colors";
 import { toCurrency } from "~/lib/legacy-util";
+import { useAppTheme } from "~/components/theme-context";
 
 interface ChartPoint {
   group: string;
@@ -94,6 +95,7 @@ export default function CostByServiceChart({
 }: CostByServiceChartProps) {
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
   const [loading, setLoading] = useState(true);
+  const { theme } = useAppTheme();
 
   useEffect(() => {
     let cancelled = false;
@@ -126,6 +128,7 @@ export default function CostByServiceChart({
   const chartOptions = useMemo(() => {
     const colorScale = buildColorScale(chartData);
     return {
+      theme,
       title: "Cloud Service Costs",
       axes: {
         left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
@@ -141,7 +144,7 @@ export default function CostByServiceChart({
         valueFormatter: (value: number) => toCurrency(value, currency),
       },
     };
-  }, [chartData, currency]);
+  }, [chartData, currency, theme]);
 
   if (loading) {
     return (
@@ -153,7 +156,7 @@ export default function CostByServiceChart({
 
   if (chartData.length === 0) {
     return (
-      <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
+      <div className="h-[400px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
         No cloud cost data available.
       </div>
     );

--- a/app/components/cost-summary-cards.tsx
+++ b/app/components/cost-summary-cards.tsx
@@ -41,10 +41,10 @@ function MetricCard({
     <div className="metric-card">
       <div className="flex items-center justify-between mb-3">
         <div className="metric-label">{label}</div>
-        <Icon size={16} style={{ color: "#525252" }} />
+        <Icon size={16} style={{ color: "var(--cds-text-secondary)" }} />
       </div>
       {loading ? (
-        <div className="metric-value text-[#8d8d8d]">—</div>
+        <div className="metric-value text-[var(--cds-text-placeholder)]">—</div>
       ) : (
         <div className="metric-value">{value}</div>
       )}

--- a/app/components/create-dashboard-modal.tsx
+++ b/app/components/create-dashboard-modal.tsx
@@ -72,7 +72,7 @@ export default function CreateDashboardModal({
       size="sm"
     >
       <div className="mb-4">
-        <p className="mb-6 text-[#525252]">
+        <p className="mb-6 text-[var(--cds-text-secondary)]">
           Create a new custom dashboard to monitor your cloud costs
         </p>
 

--- a/app/components/dashboard-builder.tsx
+++ b/app/components/dashboard-builder.tsx
@@ -122,7 +122,7 @@ export default function DashboardBuilder({
           </Button>
           <div>
             <h2 className="text-2xl font-bold">Edit Dashboard Layout</h2>
-            <p className="text-sm text-[#525252]">
+            <p className="text-sm text-[var(--cds-text-secondary)]">
               {isDefaultDashboard
                 ? "Default dashboard layout is fixed and cannot be modified"
                 : "Customize your dashboard widgets"}
@@ -147,15 +147,15 @@ export default function DashboardBuilder({
             style={{
               border:
                 selectedWidget?.id === widget.id
-                  ? "2px solid #0f62fe"
-                  : "1px solid #e0e0e0",
+                  ? "2px solid var(--cds-focus)"
+                  : "1px solid var(--cds-border-subtle)",
             }}
             onClick={() => setSelectedWidget(widget)}
           >
             <div className="p-4 cursor-pointer min-h-[200px] flex flex-col justify-between">
               <div>
                 <h3 className="text-base font-semibold mb-2">{widget.title}</h3>
-                <p className="text-sm text-[#525252]">
+                <p className="text-sm text-[var(--cds-text-secondary)]">
                   {
                     WIDGET_TYPES.find((w) => w.value === widget.type)
                       ?.description
@@ -194,13 +194,13 @@ export default function DashboardBuilder({
 
         {!isDefaultDashboard && (
           <Tile
-            style={{ border: "2px dashed #0f62fe" }}
+            style={{ border: "2px dashed var(--cds-focus)" }}
             onClick={() => setShowAddWidget(true)}
           >
             <div className="p-4 cursor-pointer min-h-[200px] flex items-center justify-center">
               <div className="text-center">
-                <Add size={32} style={{ color: "#0f62fe" }} className="mb-2" />
-                <p className="text-sm font-semibold text-[#0f62fe]">
+                <Add size={32} style={{ color: "var(--cds-link-primary)" }} className="mb-2" />
+                <p className="text-sm font-semibold text-[var(--cds-link-primary)]">
                   Add Widget
                 </p>
               </div>
@@ -210,7 +210,7 @@ export default function DashboardBuilder({
       </div>
 
       {selectedWidget && !isDefaultDashboard && (
-        <Tile className="p-6 bg-[#f4f4f4]">
+        <Tile className="p-6 bg-[var(--cds-layer-accent)]">
           <h3 className="text-lg font-semibold mb-4">Configure Widget</h3>
           <Select
             id="widget-size"
@@ -252,7 +252,7 @@ export default function DashboardBuilder({
               />
             ))}
           </Select>
-          <p className="text-sm text-[#525252] mt-2">
+          <p className="text-sm text-[var(--cds-text-secondary)] mt-2">
             {WIDGET_TYPES.find((w) => w.value === newWidgetType)?.description}
           </p>
           <div className="mt-6">
@@ -267,7 +267,7 @@ export default function DashboardBuilder({
               <SelectItem value="3" text="3 columns (¾ width)" />
               <SelectItem value="4" text="4 columns (full width)" />
             </Select>
-            <p className="text-xs text-[#6f6f6f] mt-1">
+            <p className="text-xs text-[var(--cds-text-helper)] mt-1">
               How much horizontal space should this widget occupy?
             </p>
           </div>

--- a/app/components/dashboard-view.tsx
+++ b/app/components/dashboard-view.tsx
@@ -52,7 +52,7 @@ function WidgetRenderer({
       return (
         <Tile className="p-4">
           <h3 className="text-lg font-semibold mb-2">{widget.title}</h3>
-          <p className="text-sm text-[#525252] mb-4">
+          <p className="text-sm text-[var(--cds-text-secondary)] mb-4">
             Third-party service costs
           </p>
           <ExternalServicesChartWidget />
@@ -75,7 +75,7 @@ function WidgetRenderer({
       return (
         <Tile className="p-4">
           <h3 className="text-lg font-semibold mb-2">{widget.title}</h3>
-          <div className="p-8 text-center text-[#525252]">
+          <div className="p-8 text-center text-[var(--cds-text-secondary)]">
             Anomaly detection widget
           </div>
         </Tile>
@@ -84,7 +84,7 @@ function WidgetRenderer({
       return (
         <Tile className="p-4">
           <h3 className="text-lg font-semibold mb-2">{widget.title}</h3>
-          <div className="p-8 text-center text-[#525252]">
+          <div className="p-8 text-center text-[var(--cds-text-secondary)]">
             Carbon metrics widget
           </div>
         </Tile>
@@ -181,7 +181,7 @@ export default function DashboardView({
           </Button>
           <div>
             <h1 className="text-3xl font-bold">{dashboard.name}</h1>
-            <p className="text-sm text-[#525252]">{dashboard.description}</p>
+            <p className="text-sm text-[var(--cds-text-secondary)]">{dashboard.description}</p>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -243,7 +243,7 @@ export default function DashboardView({
         )
       ) : (
         <Tile className="p-12 text-center">
-          <p className="text-sm text-[#525252] mb-4">
+          <p className="text-sm text-[var(--cds-text-secondary)] mb-4">
             No widgets added to this dashboard
           </p>
           <Button onClick={() => setIsEditMode(true)} renderIcon={Edit}>

--- a/app/components/external-services-chart-widget.tsx
+++ b/app/components/external-services-chart-widget.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { useAppTheme } from "~/components/theme-context";
 import {
   Tabs,
   TabList,
@@ -73,15 +74,6 @@ function buildTableData(tableData: any[]): ExternalCostTableRow[] {
   }));
 }
 
-const chartOptions = {
-  title: "External Services Cost Trend",
-  axes: {
-    left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
-    bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
-  },
-  height: "400px",
-};
-
 const headers = [
   { key: "name", header: "Service" },
   { key: "cost", header: "Cost" },
@@ -97,6 +89,19 @@ export default function ExternalServicesChartWidget({
   const [chartData, setChartData] = useState<ChartPoint[]>([]);
   const [tableData, setTableData] = useState<ExternalCostTableRow[]>([]);
   const [loading, setLoading] = useState(true);
+  const { theme } = useAppTheme();
+  const chartOptions = useMemo(
+    () => ({
+      theme,
+      title: "External Services Cost Trend",
+      axes: {
+        left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
+        bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
+      },
+      height: "400px",
+    }),
+    [theme],
+  );
   const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [selectedService, setSelectedService] = useState<string | null>(null);
 
@@ -155,7 +160,7 @@ export default function ExternalServicesChartWidget({
             </div>
             <div className="w-full h-[400px]">
               {loading ? (
-                <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
+                <div className="h-[400px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
                   Loading…
                 </div>
               ) : chartData.length > 0 ? (
@@ -166,7 +171,7 @@ export default function ExternalServicesChartWidget({
                   stacked={false}
                 />
               ) : (
-                <div className="h-[400px] flex items-center justify-center text-[#8d8d8d]">
+                <div className="h-[400px] flex items-center justify-center text-[var(--cds-text-placeholder)]">
                   No external cost data available. Configure external cost
                   integrations to see data here.
                 </div>
@@ -176,9 +181,9 @@ export default function ExternalServicesChartWidget({
           <TabPanel>
             <div className="mt-4">
               {loading ? (
-                <p className="text-[#8d8d8d]">Loading…</p>
+                <p className="text-[var(--cds-text-placeholder)]">Loading…</p>
               ) : tableData.length === 0 ? (
-                <p className="text-[#8d8d8d]">
+                <p className="text-[var(--cds-text-placeholder)]">
                   No external cost data available.
                 </p>
               ) : (
@@ -233,11 +238,11 @@ export default function ExternalServicesChartWidget({
               )}
 
               {selectedService && (
-                <Tile className="mt-4 p-4 bg-[#f4f4f4]">
+                <Tile className="mt-4 p-4 bg-[var(--cds-layer-accent)]">
                   <h4 className="font-semibold mb-2">
                     {selectedService} Details
                   </h4>
-                  <p className="text-sm text-[#525252]">
+                  <p className="text-sm text-[var(--cds-text-secondary)]">
                     Service: {selectedService}
                   </p>
                 </Tile>

--- a/app/components/external-services-chart-widget.tsx
+++ b/app/components/external-services-chart-widget.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useAppTheme } from "~/components/theme-context";
 import {
   Tabs,
@@ -90,18 +90,15 @@ export default function ExternalServicesChartWidget({
   const [tableData, setTableData] = useState<ExternalCostTableRow[]>([]);
   const [loading, setLoading] = useState(true);
   const { theme } = useAppTheme();
-  const chartOptions = useMemo(
-    () => ({
-      theme,
-      title: "External Services Cost Trend",
-      axes: {
-        left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
-        bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
-      },
-      height: "400px",
-    }),
-    [theme],
-  );
+  const chartOptions = {
+    theme,
+    title: "External Services Cost Trend",
+    axes: {
+      left: { mapsTo: "value", scaleType: ScaleTypes.LINEAR },
+      bottom: { mapsTo: "group", scaleType: ScaleTypes.LABELS },
+    },
+    height: "400px",
+  };
   const [chartMode, setChartMode] = useState<ChartMode>("bar");
   const [selectedService, setSelectedService] = useState<string | null>(null);
 

--- a/app/components/scoped-views.tsx
+++ b/app/components/scoped-views.tsx
@@ -133,7 +133,7 @@ export function FilterableWidgetHeader({
         <div className="flex-1 min-w-0">
           <h3 className="text-lg font-semibold m-0">{title}</h3>
           {description && (
-            <p className="text-sm text-[#525252] mt-1 mb-0">{description}</p>
+            <p className="text-sm text-[var(--cds-text-secondary)] mt-1 mb-0">{description}</p>
           )}
         </div>
         <div className="flex items-center gap-2">
@@ -150,7 +150,7 @@ export function FilterableWidgetHeader({
         </div>
       </div>
       {expanded && filterContent && (
-        <div className="mt-4 pt-4 border-t border-[#e0e0e0]">
+        <div className="mt-4 pt-4 border-t border-[var(--cds-border-subtle)]">
           {filterContent}
         </div>
       )}

--- a/app/components/theme-context.tsx
+++ b/app/components/theme-context.tsx
@@ -1,0 +1,97 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+export type ThemeName = "white" | "g100";
+
+export const THEME_STORAGE_KEY = "opencost-theme";
+
+interface ThemeContextValue {
+  theme: ThemeName;
+  setTheme: (theme: ThemeName) => void;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+function readStoredTheme(): ThemeName | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    return raw === "white" || raw === "g100" ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+function readPreferredTheme(): ThemeName {
+  if (typeof window === "undefined" || !window.matchMedia) return "white";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "g100"
+    : "white";
+}
+
+function applyThemeToDocument(theme: ThemeName) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.setAttribute("data-carbon-theme", theme);
+  root.classList.remove("cds--white", "cds--g100");
+  root.classList.add(theme === "g100" ? "cds--g100" : "cds--white");
+  root.style.colorScheme = theme === "g100" ? "dark" : "light";
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeName>("white");
+
+  useEffect(() => {
+    const initial = readStoredTheme() ?? readPreferredTheme();
+    setThemeState(initial);
+    applyThemeToDocument(initial);
+  }, []);
+
+  useEffect(() => {
+    if (readStoredTheme()) return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const onChange = (e: MediaQueryListEvent) => {
+      const next: ThemeName = e.matches ? "g100" : "white";
+      setThemeState(next);
+      applyThemeToDocument(next);
+    };
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+
+  const setTheme = useCallback((next: ThemeName) => {
+    setThemeState(next);
+    applyThemeToDocument(next);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, next);
+    } catch {}
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setTheme(theme === "g100" ? "white" : "g100");
+  }, [theme, setTheme]);
+
+  const value = useMemo(
+    () => ({ theme, setTheme, toggleTheme }),
+    [theme, setTheme, toggleTheme],
+  );
+
+  return (
+    <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+  );
+}
+
+export function useAppTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useAppTheme must be used within ThemeProvider");
+  }
+  return ctx;
+}

--- a/app/components/theme-context.tsx
+++ b/app/components/theme-context.tsx
@@ -45,30 +45,44 @@ function applyThemeToDocument(theme: ThemeName) {
   root.style.colorScheme = theme === "g100" ? "dark" : "light";
 }
 
+function readDocumentTheme(): ThemeName | null {
+  if (typeof document === "undefined") return null;
+  const attr = document.documentElement.getAttribute("data-carbon-theme");
+  return attr === "white" || attr === "g100" ? attr : null;
+}
+
+function resolveInitialTheme(): ThemeName {
+  return (
+    readDocumentTheme() ?? readStoredTheme() ?? readPreferredTheme() ?? "white"
+  );
+}
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setThemeState] = useState<ThemeName>("white");
+  const [theme, setThemeState] = useState<ThemeName>(resolveInitialTheme);
 
   useEffect(() => {
-    const initial = readStoredTheme() ?? readPreferredTheme();
-    setThemeState(initial);
-    applyThemeToDocument(initial);
-  }, []);
+    applyThemeToDocument(theme);
+  }, [theme]);
 
   useEffect(() => {
     if (readStoredTheme()) return;
+    if (typeof window === "undefined" || !window.matchMedia) return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = (e: MediaQueryListEvent) => {
-      const next: ThemeName = e.matches ? "g100" : "white";
-      setThemeState(next);
-      applyThemeToDocument(next);
+      setThemeState(e.matches ? "g100" : "white");
     };
-    mq.addEventListener("change", onChange);
-    return () => mq.removeEventListener("change", onChange);
+    // Safari < 14 and some mobile browsers only support the deprecated
+    // addListener/removeListener API.
+    if (typeof mq.addEventListener === "function") {
+      mq.addEventListener("change", onChange);
+      return () => mq.removeEventListener("change", onChange);
+    }
+    mq.addListener(onChange);
+    return () => mq.removeListener(onChange);
   }, []);
 
   const setTheme = useCallback((next: ThemeName) => {
     setThemeState(next);
-    applyThemeToDocument(next);
     try {
       window.localStorage.setItem(THEME_STORAGE_KEY, next);
     } catch {}

--- a/app/components/theme-context.tsx
+++ b/app/components/theme-context.tsx
@@ -65,10 +65,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   }, [theme]);
 
   useEffect(() => {
-    if (readStoredTheme()) return;
     if (typeof window === "undefined" || !window.matchMedia) return;
     const mq = window.matchMedia("(prefers-color-scheme: dark)");
     const onChange = (e: MediaQueryListEvent) => {
+      // Respect an explicit user choice once one has been persisted — only
+      // follow the OS preference while no stored theme exists.
+      if (readStoredTheme()) return;
       setThemeState(e.matches ? "g100" : "white");
     };
     // Safari < 14 and some mobile browsers only support the deprecated

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -40,7 +40,9 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
-        <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
+        {!isLegacyMode && (
+          <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
+        )}
       </head>
       <body>
         {children}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,8 +29,30 @@ const DashboardApp = lazy(() =>
 );
 
 // Applies the persisted / preferred theme before React hydrates so the first
-// paint matches the user's choice (avoids a light-to-dark flash).
-const themeBootstrap = `(function(){try{var s=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});var t=(s==='white'||s==='g100')?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'g100':'white');var r=document.documentElement;r.setAttribute('data-carbon-theme',t);r.classList.remove('cds--white','cds--g100');r.classList.add(t==='g100'?'cds--g100':'cds--white');r.style.colorScheme=t==='g100'?'dark':'light';}catch(e){}})();`;
+// paint matches the user's choice (avoids a light-to-dark flash). The
+// localStorage read is isolated in its own try/catch so that the matchMedia
+// fallback and DOM updates still run when storage is unavailable (disabled
+// cookies, some private modes, sandboxed iframes).
+const themeBootstrap = `(function () {
+  try {
+    var stored = null;
+    try {
+      stored = window.localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});
+    } catch (e) {}
+    var theme =
+      stored === 'white' || stored === 'g100'
+        ? stored
+        : window.matchMedia &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'g100'
+          : 'white';
+    var root = document.documentElement;
+    root.setAttribute('data-carbon-theme', theme);
+    root.classList.remove('cds--white', 'cds--g100');
+    root.classList.add(theme === 'g100' ? 'cds--g100' : 'cds--white');
+    root.style.colorScheme = theme === 'g100' ? 'dark' : 'light';
+  } catch (e) {}
+})();`;
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,7 +13,7 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import type { Route } from "./+types/root";
 import "./app.scss";
 import "./tailwind.css";
-import { ThemeProvider } from "~/components/theme-context";
+import { ThemeProvider, THEME_STORAGE_KEY } from "~/components/theme-context";
 import AppMuiThemeBridge from "~/components/app-mui-theme-bridge";
 
 const isLegacyMode = import.meta.env.VITE_LEGACY_MODE === "true";
@@ -30,7 +30,7 @@ const DashboardApp = lazy(() =>
 
 // Applies the persisted / preferred theme before React hydrates so the first
 // paint matches the user's choice (avoids a light-to-dark flash).
-const themeBootstrap = `(function(){try{var s=localStorage.getItem('opencost-theme');var t=(s==='white'||s==='g100')?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'g100':'white');var r=document.documentElement;r.setAttribute('data-carbon-theme',t);r.classList.remove('cds--white','cds--g100');r.classList.add(t==='g100'?'cds--g100':'cds--white');r.style.colorScheme=t==='g100'?'dark':'light';}catch(e){}})();`;
+const themeBootstrap = `(function(){try{var s=localStorage.getItem(${JSON.stringify(THEME_STORAGE_KEY)});var t=(s==='white'||s==='g100')?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'g100':'white');var r=document.documentElement;r.setAttribute('data-carbon-theme',t);r.classList.remove('cds--white','cds--g100');r.classList.add(t==='g100'?'cds--g100':'cds--white');r.style.colorScheme=t==='g100'?'dark':'light';}catch(e){}})();`;
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
@@ -52,18 +52,20 @@ export function Layout({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
-  const content = isLegacyMode ? (
-    <Outlet />
-  ) : (
-    <Suspense fallback={null}>
-      <DashboardApp />
-    </Suspense>
-  );
+  if (isLegacyMode) {
+    return (
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <Outlet />
+      </LocalizationProvider>
+    );
+  }
   return (
     <ThemeProvider>
       <AppMuiThemeBridge>
         <LocalizationProvider dateAdapter={AdapterDateFns}>
-          {content}
+          <Suspense fallback={null}>
+            <DashboardApp />
+          </Suspense>
         </LocalizationProvider>
       </AppMuiThemeBridge>
     </ThemeProvider>

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -13,6 +13,8 @@ import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import type { Route } from "./+types/root";
 import "./app.scss";
 import "./tailwind.css";
+import { ThemeProvider } from "~/components/theme-context";
+import AppMuiThemeBridge from "~/components/app-mui-theme-bridge";
 
 const isLegacyMode = import.meta.env.VITE_LEGACY_MODE === "true";
 
@@ -26,6 +28,10 @@ const DashboardApp = lazy(() =>
   })),
 );
 
+// Applies the persisted / preferred theme before React hydrates so the first
+// paint matches the user's choice (avoids a light-to-dark flash).
+const themeBootstrap = `(function(){try{var s=localStorage.getItem('opencost-theme');var t=(s==='white'||s==='g100')?s:(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches?'g100':'white');var r=document.documentElement;r.setAttribute('data-carbon-theme',t);r.classList.remove('cds--white','cds--g100');r.classList.add(t==='g100'?'cds--g100':'cds--white');r.style.colorScheme=t==='g100'?'dark':'light';}catch(e){}})();`;
+
 export function Layout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
@@ -34,6 +40,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <Meta />
         <Links />
+        <script dangerouslySetInnerHTML={{ __html: themeBootstrap }} />
       </head>
       <body>
         {children}
@@ -53,9 +60,13 @@ export default function App() {
     </Suspense>
   );
   return (
-    <LocalizationProvider dateAdapter={AdapterDateFns}>
-      {content}
-    </LocalizationProvider>
+    <ThemeProvider>
+      <AppMuiThemeBridge>
+        <LocalizationProvider dateAdapter={AdapterDateFns}>
+          {content}
+        </LocalizationProvider>
+      </AppMuiThemeBridge>
+    </ThemeProvider>
   );
 }
 
@@ -78,9 +89,9 @@ export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
   return (
     <main className="p-[4rem_2rem] max-w-[600px] mx-auto">
       <h1 className="text-[2rem] font-bold mb-4">{message}</h1>
-      <p className="text-[#525252] mb-4">{details}</p>
+      <p className="text-[var(--cds-text-secondary)] mb-4">{details}</p>
       {stack && (
-        <pre className="bg-[#f4f4f4] p-4 overflow-x-auto text-[0.8rem]">
+        <pre className="bg-[var(--cds-layer)] p-4 overflow-x-auto text-[0.8rem]">
           <code>{stack}</code>
         </pre>
       )}

--- a/app/routes/dashboard-list.tsx
+++ b/app/routes/dashboard-list.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router";
-import { Button, Header, HeaderName, Tag, Modal } from "@carbon/react";
+import { Button, Tag, Modal } from "@carbon/react";
 import { Add, Dashboard, ChartLineSmooth, Activity } from "@carbon/icons-react";
 import {
   useDashboard,
@@ -8,6 +8,7 @@ import {
   type Widget,
 } from "~/components/dashboard-context";
 import CreateDashboardModal from "~/components/create-dashboard-modal";
+import AppHeader from "~/components/app-header";
 
 interface SharedDashboardPayload {
   name: string;
@@ -76,11 +77,8 @@ export default function DashboardList() {
 
   return (
     <>
-      <Header aria-label="OpenCost Platform">
-        <HeaderName href="/" prefix="">
-          <img src="/logo.png" alt="OpenCost" className="h-6" />
-        </HeaderName>
-        <div className="ml-auto flex items-center pr-4">
+      <AppHeader>
+        <div className="flex items-center pr-4">
           <Button
             onClick={() => setShowCreateModal(true)}
             renderIcon={Add}
@@ -89,13 +87,13 @@ export default function DashboardList() {
             Create Dashboard
           </Button>
         </div>
-      </Header>
+      </AppHeader>
 
-      <main className="pt-12 min-h-screen bg-[#f4f4f4]">
+      <main className="pt-12 min-h-screen bg-[var(--cds-background)]">
         <div className="p-8 max-w-[1584px] mx-auto">
           <div className="mb-8">
             <h2 className="text-[2rem] font-normal mb-2">Dashboards</h2>
-            <p className="text-[#525252] text-sm">
+            <p className="text-[var(--cds-text-secondary)] text-sm">
               Monitor and analyze your cloud infrastructure costs
             </p>
           </div>
@@ -104,8 +102,11 @@ export default function DashboardList() {
           <div className="grid gap-4 grid-cols-3 mb-8">
             <div className="metric-card">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-[#e0e0e0] rounded-lg flex">
-                  <Dashboard size={20} style={{ color: "#0f62fe" }} />
+                <div className="p-2 bg-[var(--cds-layer-accent)] rounded-lg flex">
+                  <Dashboard
+                    size={20}
+                    style={{ color: "var(--cds-icon-interactive)" }}
+                  />
                 </div>
                 <span className="metric-label">Total Dashboards</span>
               </div>
@@ -114,8 +115,11 @@ export default function DashboardList() {
 
             <div className="metric-card">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-[#defbe6] rounded-lg flex">
-                  <ChartLineSmooth size={20} style={{ color: "#198038" }} />
+                <div className="p-2 bg-[var(--cds-layer-accent)] rounded-lg flex">
+                  <ChartLineSmooth
+                    size={20}
+                    style={{ color: "var(--cds-support-success)" }}
+                  />
                 </div>
                 <span className="metric-label">Total Widgets</span>
               </div>
@@ -126,8 +130,11 @@ export default function DashboardList() {
 
             <div className="metric-card">
               <div className="flex items-center gap-3 mb-3">
-                <div className="p-2 bg-[#bae6ff] rounded-lg flex">
-                  <Activity size={20} style={{ color: "#0072c3" }} />
+                <div className="p-2 bg-[var(--cds-layer-accent)] rounded-lg flex">
+                  <Activity
+                    size={20}
+                    style={{ color: "var(--cds-support-info)" }}
+                  />
                 </div>
                 <span className="metric-label">Active Monitoring</span>
               </div>
@@ -144,8 +151,11 @@ export default function DashboardList() {
                 className="card-enhanced p-6 cursor-pointer block no-underline text-inherit hover:no-underline focus:no-underline"
               >
                 <div className="flex items-start justify-between mb-4">
-                  <div className="p-[0.625rem] bg-[#e0e0e0] rounded-lg flex">
-                    <Dashboard size={20} style={{ color: "#0f62fe" }} />
+                  <div className="p-[0.625rem] bg-[var(--cds-layer-accent)] rounded-lg flex">
+                    <Dashboard
+                      size={20}
+                      style={{ color: "var(--cds-icon-interactive)" }}
+                    />
                   </div>
                   <div className="flex items-center gap-2">
                     <Tag type="gray" size="sm">
@@ -155,15 +165,15 @@ export default function DashboardList() {
                 </div>
 
                 <h3 className="font-semibold text-lg mb-2">{dashboard.name}</h3>
-                <p className="text-sm text-[#525252] mb-4">
+                <p className="text-sm text-[var(--cds-text-secondary)] mb-4">
                   {dashboard.description}
                 </p>
 
-                <div className="flex items-center justify-between pt-4 border-t border-[#e0e0e0]">
-                  <span className="text-xs text-[#8d8d8d]">
+                <div className="flex items-center justify-between pt-4 border-t border-[var(--cds-border-subtle)]">
+                  <span className="text-xs text-[var(--cds-text-placeholder)]">
                     Updated {timeAgo(dashboard.updatedAt)}
                   </span>
-                  <span className="text-xs text-[#8d8d8d]">
+                  <span className="text-xs text-[var(--cds-text-placeholder)]">
                     by {dashboard.owner}
                   </span>
                 </div>
@@ -195,20 +205,20 @@ export default function DashboardList() {
       >
         {sharedPayload && (
           <div>
-            <p className="mb-4 text-sm text-[#525252]">
+            <p className="mb-4 text-sm text-[var(--cds-text-secondary)]">
               Someone shared a dashboard configuration with you. Would you like
               to import it?
             </p>
-            <div className="p-4 bg-[#f4f4f4] border-l-4 border-[#0f62fe] mb-4">
+            <div className="p-4 bg-[var(--cds-layer-accent)] border-l-4 border-[var(--cds-focus)] mb-4">
               <p className="font-semibold text-base mb-1">
                 {sharedPayload.name}
               </p>
               {sharedPayload.description && (
-                <p className="text-sm text-[#525252] mb-2">
+                <p className="text-sm text-[var(--cds-text-secondary)] mb-2">
                   {sharedPayload.description}
                 </p>
               )}
-              <p className="text-xs text-[#8d8d8d]">
+              <p className="text-xs text-[var(--cds-text-placeholder)]">
                 {sharedPayload.widgets.length} widget
                 {sharedPayload.widgets.length !== 1 ? "s" : ""}
                 {sharedPayload.tags?.length
@@ -216,7 +226,7 @@ export default function DashboardList() {
                   : ""}
               </p>
             </div>
-            <p className="text-xs text-[#8d8d8d]">
+            <p className="text-xs text-[var(--cds-text-placeholder)]">
               This will be added as a new dashboard in your workspace. No
               existing dashboards will be affected.
             </p>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,7 +1,7 @@
 import { useParams, useNavigate } from "react-router";
-import { Header, HeaderName } from "@carbon/react";
 import { useDashboard } from "~/components/dashboard-context";
 import DashboardView from "~/components/dashboard-view";
+import AppHeader from "~/components/app-header";
 import type { Widget } from "~/components/dashboard-context";
 
 export function meta() {
@@ -18,19 +18,15 @@ export default function DashboardPage() {
   if (!dashboard) {
     return (
       <>
-        <Header aria-label="OpenCost Platform">
-          <HeaderName href="/" prefix="">
-            <img src="/logo.png" alt="OpenCost" className="h-6" />
-          </HeaderName>
-        </Header>
+        <AppHeader />
         <main className="pt-12 p-[4rem_2rem] text-center">
           <h2 className="text-2xl font-semibold mb-4">Dashboard not found</h2>
-          <p className="text-[#525252] mb-6">
+          <p className="text-[var(--cds-text-secondary)] mb-6">
             The dashboard you are looking for does not exist.
           </p>
           <button
             onClick={() => navigate("/")}
-            className="bg-[#0f62fe] text-white border-none py-3 px-6 cursor-pointer text-sm"
+            className="bg-[var(--cds-button-primary)] text-[var(--cds-text-on-color)] border-none py-3 px-6 cursor-pointer text-sm"
           >
             Back to Dashboards
           </button>
@@ -45,12 +41,8 @@ export default function DashboardPage() {
 
   return (
     <>
-      <Header aria-label="OpenCost Platform">
-        <HeaderName href="/" prefix="">
-          <img src="/logo.png" alt="OpenCost" className="h-6" />
-        </HeaderName>
-      </Header>
-      <main className="pt-20 pb-8 min-h-screen bg-[#f4f4f4]">
+      <AppHeader />
+      <main className="pt-20 pb-8 min-h-screen bg-[var(--cds-background)]">
         <DashboardView
           dashboard={dashboard}
           onBack={() => navigate("/")}


### PR DESCRIPTION
Closes #240.

## Summary
- Wires Carbon's official `white` and `g100` themes via the SCSS `theme()` mixin so every `--cds-*` token re-emits under `:root`/`.cds--white` and `[data-carbon-theme="g100"]`/`.cds--g100`.
- Adds a `ThemeProvider` with `localStorage` persistence and `prefers-color-scheme` fallback, plus a pre-hydration inline script in `root.tsx` to apply the resolved theme before React paints (no light/dark flash).
- Adds a shared `AppHeader` with a Carbon `HeaderGlobalAction` sun/moon toggle (`@carbon/icons-react` `Light`/`Asleep`) and wires it into the dashboard-list and dashboard routes.
- Replaces hardcoded hex colors (`#f4f4f4`, `#525252`, `#161616`, `#8d8d8d`, `#0f62fe`, `#e0e0e0`, ...) across non-legacy routes/components with Carbon tokens (`--cds-background`, `--cds-text-primary`, `--cds-layer`, `--cds-border-subtle`, `--cds-focus`, ...).
- Threads the active theme into `@carbon/charts` via `options.theme` in every non-legacy chart widget.
- Bridges MUI to the same theme via `palette.mode` so date-picker popovers match.

Legacy UI is intentionally out of scope for this change.

## Test plan
- [ ] `npm run dev` → dashboards page loads; header shows moon icon on light theme
- [ ] Click toggle → entire UI flips to `g100` (dark); icon switches to sun
- [ ] Reload → theme persists via `localStorage["opencost-theme"]`
- [ ] Clear storage, set OS preference to dark → first load resolves to `g100` with no light-to-dark flash
- [ ] Navigate into a dashboard → Carbon charts (bar/area/pie) render in the active theme
- [ ] Open a MUI date picker → popover background/text match the active theme
- [ ] Legacy routes (`/legacy/*`) unchanged

Assisted-by: Claude Code
