### PR TITLE
fix: README media preview (image and video thumbnail not loading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 # OpenCost UI
 
-<img src="src/images/logo.png"/>
+<img src="public/logo.png"/>
 
 This is the web UI for the [OpenCost](http://github.com/opencost/opencost) project. You can learn more about the [User Interface](https://www.opencost.io/docs/installation/ui) in the OpenCost docs.
 
-[![OpenCost UI Walkthrough](./src/thumbnail.png)](https://youtu.be/lCP4Ci9Kcdg)
+[![OpenCost UI Walkthrough](https://img.youtube.com/vi/lCP4Ci9Kcdg/maxresdefault.jpg)](https://youtu.be/lCP4Ci9Kcdg)
 _OpenCost UI Walkthrough_
 
 ## Installing


### PR DESCRIPTION
## Fixes #249

### What was the issue

Some README assets were broken after refactoring:

* Image paths were pointing to `src/` which no longer exists
* The video thumbnail (`thumbnail.png`) was also removed

### What was changed

* Updated the logo to use `public/logo.png`
* Replaced the broken thumbnail with YouTube’s auto-generated preview

### Why this approach

Since the thumbnail file isn’t in the repo anymore, I used YouTube’s preview instead of adding a new image:

```
https://img.youtube.com/vi/<VIDEO_ID>/maxresdefault.jpg
```

### Result

* Images render correctly
* Video preview works again