### PR TITLE
Fix Dockerfile.debug build output path

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -23,11 +23,11 @@ ENV API_SERVER=0.0.0.0
 ENV UI_PORT=9090
 ENV UI_PATH=${ui_path}
 
-COPY ./dist /opt/ui/dist
+RUN mkdir -p /var/www
+COPY ./build/client /var/www
 COPY default.nginx.conf.template /etc/nginx/conf.d/default.nginx.conf.template
 COPY nginx.conf /etc/nginx/
 COPY ./docker-entrypoint.sh /usr/local/bin/
-RUN mkdir -p /var/www
 
 RUN rm -rf /etc/nginx/conf.d/default.conf
 
@@ -36,7 +36,7 @@ RUN chown 1001:1000 -R /var/www
 RUN chown 1001:1000 -R /etc/nginx
 RUN chown 1001:1000 -R /usr/local/bin/docker-entrypoint.sh
 
-ENV BASE_URL=${UI_PATH%/}/model
+ENV BASE_URL=/model
 
 USER 1001
 


### PR DESCRIPTION
## Summary

Updates **Dockerfile.debug** to use **build/client** instead of **dist**.

The UI build output has moved to **build/client**, but the debug Dockerfile still references **dist**, causing the UI image build to fail during the Tilt development workflow.

## Testing

* Ran **npm run build**
* Confirmed **build/client** was generated
* Ran **tilt up**
* Confirmed the **opencost-ui** image built successfully
* Confirmed the UI loaded successfully

Fixes #265 