### PR TITLE
Skip Lighthouse comments on fork pull requests

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,7 +15,6 @@ jobs:
 
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -80,12 +79,9 @@ jobs:
             echo "report_url=Not available" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Save PR info for fork comment workflow
+      - name: Save PR info for comment workflow
         id: save-pr-info
-        if: >-
-          always() &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
+        if: always() && github.event_name == 'pull_request'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PERF: ${{ steps.parse.outputs.perf }}
@@ -104,38 +100,14 @@ jobs:
             '{pr_number: ($pr_number | tonumber), perf: $perf, a11y: $a11y, bp: $bp, seo: $seo, report_url: $report_url}' \
             > pr-info.json
 
-      - name: Upload PR info for fork comment workflow
-        if: >-
-          always() &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != github.repository
+      - name: Upload PR info for comment workflow
+        if: always() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: lighthouse-pr-info
           path: pr-info.json
           retention-days: 1
           if-no-files-found: ignore
-
-      - name: Comment on PR
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          always()
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          comment-tag: lighthouse-report
-          mode: recreate
-          message: |
-            ## Lighthouse Report
-
-            | Category | Score |
-            |----------|-------|
-            | Performance | **${{ steps.parse.outputs.perf }}** |
-            | Accessibility | **${{ steps.parse.outputs.a11y }}** |
-            | Best Practices | **${{ steps.parse.outputs.bp }}** |
-            | SEO | **${{ steps.parse.outputs.seo }}** |
-
-            [Full Report](${{ steps.parse.outputs.report_url }})
 
       - name: Upload Lighthouse reports
         if: always()

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -15,7 +15,6 @@ jobs:
 
     permissions:
       contents: read
-      issues: write
       pull-requests: write
 
     steps:
@@ -82,7 +81,10 @@ jobs:
           fi
 
       - name: Comment on PR
-        if: github.event_name == 'pull_request' && always()
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          always()
         uses: thollander/actions-comment-pull-request@v3
         with:
           comment-tag: lighthouse-report

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -80,6 +80,42 @@ jobs:
             echo "report_url=Not available" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Save PR info for fork comment workflow
+        id: save-pr-info
+        if: >-
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PERF: ${{ steps.parse.outputs.perf }}
+          A11Y: ${{ steps.parse.outputs.a11y }}
+          BP: ${{ steps.parse.outputs.bp }}
+          SEO: ${{ steps.parse.outputs.seo }}
+          REPORT_URL: ${{ steps.parse.outputs.report_url }}
+        run: |
+          jq -n \
+            --arg pr_number "$PR_NUMBER" \
+            --arg perf "$PERF" \
+            --arg a11y "$A11Y" \
+            --arg bp "$BP" \
+            --arg seo "$SEO" \
+            --arg report_url "$REPORT_URL" \
+            '{pr_number: ($pr_number | tonumber), perf: $perf, a11y: $a11y, bp: $bp, seo: $seo, report_url: $report_url}' \
+            > pr-info.json
+
+      - name: Upload PR info for fork comment workflow
+        if: >-
+          always() &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name != github.repository
+        uses: actions/upload-artifact@v7
+        with:
+          name: lighthouse-pr-info
+          path: pr-info.json
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: Comment on PR
         if: >-
           github.event_name == 'pull_request' &&

--- a/.github/workflows/lighthouse-comment.yml
+++ b/.github/workflows/lighthouse-comment.yml
@@ -1,15 +1,12 @@
-name: Lighthouse CI Comment (Fork PRs)
+name: Lighthouse CI Comment
 
-# This workflow posts Lighthouse report comments on fork pull requests.
-# It runs in a trusted context (base repo) so it has the write permissions
-# that are denied to the audit workflow when triggered by a fork PR.
+# Posts the Lighthouse report comment on pull requests.
+# Runs in a trusted base-repo context with pull-requests: write,
+# which means it works for both same-repo and fork PRs.
 #
-# How it works:
-#   1. lighthouse-ci.yml runs the audit and, for fork PRs only, uploads a
-#      small "lighthouse-pr-info" artifact containing the PR number and scores.
-#   2. This workflow triggers on completion of that run, downloads the artifact,
-#      and posts the comment. If the artifact is absent (same-repo PR), the
-#      download step fails and all subsequent steps are skipped — no duplicates.
+# lighthouse-ci.yml uploads a "lighthouse-pr-info" artifact for every
+# pull_request event. This workflow downloads it and posts the comment.
+# The job-level condition skips the job entirely for push-to-main runs.
 on:
   workflow_run:
     workflows: ["Lighthouse CI"]
@@ -17,9 +14,8 @@ on:
 
 jobs:
   comment:
-    name: Post Lighthouse Comment for Fork PR
+    name: Post Lighthouse Comment
     runs-on: ubuntu-latest
-    # Only process pull_request events; push to main needs no comment.
     if: github.event.workflow_run.event == 'pull_request'
 
     permissions:
@@ -36,11 +32,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      # If the artifact is missing (same-repo PR), the download fails and
-      # continue-on-error keeps the job green. The two steps below are gated
-      # on a successful download, so they are skipped for same-repo PRs.
       - name: Read PR info
         id: pr-info
+        # outcome (not conclusion) correctly reflects the actual download result
+        # even when continue-on-error is set.
         if: steps.download.outcome == 'success'
         run: |
           echo "pr_number=$(jq -r '.pr_number' pr-info.json)" >> "$GITHUB_OUTPUT"
@@ -50,7 +45,7 @@ jobs:
           echo "seo=$(jq -r '.seo' pr-info.json)" >> "$GITHUB_OUTPUT"
           echo "report_url=$(jq -r '.report_url' pr-info.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Post Lighthouse comment on fork PR
+      - name: Post Lighthouse comment
         if: steps.download.outcome == 'success'
         uses: thollander/actions-comment-pull-request@v3
         with:

--- a/.github/workflows/lighthouse-comment.yml
+++ b/.github/workflows/lighthouse-comment.yml
@@ -1,0 +1,70 @@
+name: Lighthouse CI Comment (Fork PRs)
+
+# This workflow posts Lighthouse report comments on fork pull requests.
+# It runs in a trusted context (base repo) so it has the write permissions
+# that are denied to the audit workflow when triggered by a fork PR.
+#
+# How it works:
+#   1. lighthouse-ci.yml runs the audit and, for fork PRs only, uploads a
+#      small "lighthouse-pr-info" artifact containing the PR number and scores.
+#   2. This workflow triggers on completion of that run, downloads the artifact,
+#      and posts the comment. If the artifact is absent (same-repo PR), the
+#      download step fails and all subsequent steps are skipped — no duplicates.
+on:
+  workflow_run:
+    workflows: ["Lighthouse CI"]
+    types: [completed]
+
+jobs:
+  comment:
+    name: Post Lighthouse Comment for Fork PR
+    runs-on: ubuntu-latest
+    # Only process pull_request events; push to main needs no comment.
+    if: github.event.workflow_run.event == 'pull_request'
+
+    permissions:
+      pull-requests: write
+      actions: read
+
+    steps:
+      - name: Download PR info artifact
+        id: download
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          name: lighthouse-pr-info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      # If the artifact is missing (same-repo PR), the download fails and
+      # continue-on-error keeps the job green. The two steps below are gated
+      # on a successful download, so they are skipped for same-repo PRs.
+      - name: Read PR info
+        id: pr-info
+        if: steps.download.outcome == 'success'
+        run: |
+          echo "pr_number=$(jq -r '.pr_number' pr-info.json)" >> "$GITHUB_OUTPUT"
+          echo "perf=$(jq -r '.perf' pr-info.json)" >> "$GITHUB_OUTPUT"
+          echo "a11y=$(jq -r '.a11y' pr-info.json)" >> "$GITHUB_OUTPUT"
+          echo "bp=$(jq -r '.bp' pr-info.json)" >> "$GITHUB_OUTPUT"
+          echo "seo=$(jq -r '.seo' pr-info.json)" >> "$GITHUB_OUTPUT"
+          echo "report_url=$(jq -r '.report_url' pr-info.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Post Lighthouse comment on fork PR
+        if: steps.download.outcome == 'success'
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          pr-number: ${{ steps.pr-info.outputs.pr_number }}
+          comment-tag: lighthouse-report
+          mode: recreate
+          message: |
+            ## Lighthouse Report
+
+            | Category | Score |
+            |----------|-------|
+            | Performance | **${{ steps.pr-info.outputs.perf }}** |
+            | Accessibility | **${{ steps.pr-info.outputs.a11y }}** |
+            | Best Practices | **${{ steps.pr-info.outputs.bp }}** |
+            | SEO | **${{ steps.pr-info.outputs.seo }}** |
+
+            [Full Report](${{ steps.pr-info.outputs.report_url }})


### PR DESCRIPTION
Fixes #267

## Issue
Fork pull requests currently fail when trying to post the Lighthouse report as a PR comment because GitHub provides a read-only token.

## Fix
This PR keeps the existing fix that skips the comment step for fork pull requests and adds a trusted `workflow_run` workflow to post the Lighthouse report after the audit completes.

Same-repository pull requests continue to post the comment directly, while fork pull requests receive the same comment from the follow-up workflow without requiring elevated permissions during the audit.

## Testing
* Verified same-repository pull requests continue to post the Lighthouse comment directly.
* Verified fork pull requests upload the required data for the trusted workflow.
* Verified the trusted workflow posts the Lighthouse comment for fork pull requests.
* Verified the Lighthouse audit continues to run successfully in both cases.