### PR TITLE
feat(allocation): custom label aggregation in home + report dropdowns

### DIFF
--- a/app/components/report-builder-side-panel.tsx
+++ b/app/components/report-builder-side-panel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { Button } from "@carbon/react";
+import { Button, ComboBox, Theme } from "@carbon/react";
 import { DeleteOutlined } from "@mui/icons-material";
 import {
   REPORT_WINDOW_PRESETS,
@@ -61,6 +61,54 @@ function isInfraAssetsQuery(query: Report["query"]): query is InfraAssetsReportQ
 
 function isExternalCostQuery(query: Report["query"]): query is ExternalCostReportQuery {
   return query.layer === "externalCost";
+}
+
+type GroupingOption = { label: string; value: string };
+
+function GroupingComboBox({
+  index,
+  grouping,
+  onChange,
+}: {
+  index: number;
+  grouping: string;
+  onChange: (value: string) => void;
+}) {
+  const presetMatch = ALLOCATION_GROUPING_OPTIONS.find((o) => o.value === grouping);
+  const selectedItem: GroupingOption =
+    presetMatch ?? { label: grouping, value: grouping };
+  const items: GroupingOption[] = presetMatch
+    ? ALLOCATION_GROUPING_OPTIONS
+    : [...ALLOCATION_GROUPING_OPTIONS, selectedItem];
+
+  return (
+    <Theme theme="white">
+      <ComboBox
+        id={index === 0 ? "report-grouping-0" : `report-grouping-${index}`}
+        aria-label={`Grouping ${index + 1}`}
+        size="md"
+        items={items}
+        itemToString={(item: GroupingOption | null) => item?.label ?? ""}
+        selectedItem={selectedItem}
+        allowCustomValue
+        onChange={({
+          selectedItem: picked,
+          inputValue,
+        }: {
+          selectedItem?: GroupingOption | null;
+          inputValue?: string | null;
+        }) => {
+          if (picked) {
+            onChange(picked.value);
+            return;
+          }
+          const typed = (inputValue ?? "").trim();
+          if (!typed || typed === grouping) return;
+          onChange(typed.includes(":") ? typed : `label:${typed}`);
+        }}
+      />
+    </Theme>
+  );
 }
 
 function toFilterOptionsByLayer(layer: ReportLayer) {
@@ -414,19 +462,13 @@ export default function ReportBuilderSidePanel({
             <div className="space-y-2">
               {groupings.map((grouping, index) => (
                 <div key={`grouping-${index}-${grouping}`} className="flex items-center gap-2">
-                  <select
-                    id={index === 0 ? "report-grouping-0" : undefined}
-                    aria-label={`Grouping ${index + 1}`}
-                    value={grouping}
-                    onChange={(event) => setGroupingAt(index, event.target.value)}
-                    className="h-10 min-w-0 flex-1 rounded border border-[var(--cds-border-subtle)] bg-[var(--cds-layer)] px-2.5 text-[13px] text-[var(--cds-text-primary)]"
-                  >
-                    {ALLOCATION_GROUPING_OPTIONS.map((groupingOption) => (
-                      <option key={groupingOption.value} value={groupingOption.value}>
-                        {groupingOption.label}
-                      </option>
-                    ))}
-                  </select>
+                  <div className="min-w-0 flex-1">
+                    <GroupingComboBox
+                      index={index}
+                      grouping={grouping}
+                      onChange={(value) => setGroupingAt(index, value)}
+                    />
+                  </div>
                   <button
                     type="button"
                     disabled={groupings.length <= 1}

--- a/app/components/scoped-views.tsx
+++ b/app/components/scoped-views.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectItem } from "@carbon/react";
+import { Select, SelectItem, ComboBox } from "@carbon/react";
 import { Tune } from "@mui/icons-material";
 import {
   CLOUD_WINDOW_OPTIONS,
@@ -6,6 +6,8 @@ import {
   CLOUD_COST_METRIC_OPTIONS,
 } from "~/constants/cloud-cost-options";
 import { REPORT_ACCUMULATE_OPTIONS } from "~/types/report";
+
+type AggregateOption = { name: string; value: string };
 
 export const ALLOCATION_WINDOW_OPTIONS = [
   { name: "Today", value: "today" },
@@ -31,6 +33,10 @@ export const ALLOCATION_AGGREGATE_OPTIONS = [
   { name: "StatefulSet", value: "statefulset" },
   { name: "Pod", value: "pod" },
   { name: "Container", value: "container" },
+  {
+    name: "label:app.kubernetes.io/name",
+    value: "label:app.kubernetes.io/name",
+  },
 ];
 
 export const DEFAULT_ALLOCATION_FILTERS = {
@@ -193,6 +199,52 @@ interface AllocationFilterControlsProps {
   compact?: boolean;
 }
 
+function AllocationAggregateByCombo({
+  idPrefix,
+  aggregateBy,
+  onAggregateByChange,
+}: {
+  idPrefix: string;
+  aggregateBy: string;
+  onAggregateByChange: (v: string) => void;
+}) {
+  const presetMatch = ALLOCATION_AGGREGATE_OPTIONS.find(
+    (o) => o.value === aggregateBy,
+  );
+  const selectedItem: AggregateOption =
+    presetMatch ?? { name: aggregateBy, value: aggregateBy };
+  const items: AggregateOption[] = presetMatch
+    ? ALLOCATION_AGGREGATE_OPTIONS
+    : [...ALLOCATION_AGGREGATE_OPTIONS, selectedItem];
+
+  return (
+    <ComboBox
+      id={`${idPrefix}-aggregate`}
+      titleText="Aggregate by"
+      size="sm"
+      items={items}
+      itemToString={(item: AggregateOption | null) => item?.name ?? ""}
+      selectedItem={selectedItem}
+      allowCustomValue
+      onChange={({
+        selectedItem: picked,
+        inputValue,
+      }: {
+        selectedItem?: AggregateOption | null;
+        inputValue?: string | null;
+      }) => {
+        if (picked) {
+          onAggregateByChange(picked.value);
+          return;
+        }
+        const typed = (inputValue ?? "").trim();
+        if (!typed || typed === aggregateBy) return;
+        onAggregateByChange(typed.includes(":") ? typed : `label:${typed}`);
+      }}
+    />
+  );
+}
+
 export function AllocationFilterControls({
   window,
   aggregateBy,
@@ -227,17 +279,11 @@ export function AllocationFilterControls({
           <SelectItem key={o.value} value={o.value} text={o.name} />
         ))}
       </Select>
-      <Select
-        id={`${idPrefix}-aggregate`}
-        labelText="Aggregate by"
-        value={aggregateBy}
-        size="sm"
-        onChange={(e) => onAggregateByChange(e.target.value)}
-      >
-        {ALLOCATION_AGGREGATE_OPTIONS.map((o) => (
-          <SelectItem key={o.value} value={o.value} text={o.name} />
-        ))}
-      </Select>
+      <AllocationAggregateByCombo
+        idPrefix={idPrefix}
+        aggregateBy={aggregateBy}
+        onAggregateByChange={onAggregateByChange}
+      />
       <Select
         id={`${idPrefix}-accumulate`}
         labelText="Granularity"

--- a/app/types/report.ts
+++ b/app/types/report.ts
@@ -138,6 +138,10 @@ export const ALLOCATION_GROUPING_OPTIONS = [
   { label: "Service", value: "service" },
   { label: "Pod", value: "pod" },
   { label: "Container", value: "container" },
+  {
+    label: "label:app.kubernetes.io/name",
+    value: "label:app.kubernetes.io/name",
+  },
 ];
 
 export const CLOUD_COST_GROUPING_OPTIONS = [


### PR DESCRIPTION
## What does this PR change?

- Replaces the home-page Cost Allocation "Aggregate by" Select with a Carbon ComboBox that accepts either a preset workload type or a free-text label key. Bare keys are auto-prefixed with `label:` before being passed to `/allocation/compute`, which already supports `aggregate=label:<key>`.
- Mirrors the same pattern on the Report Builder side panel's per-row Groupings selector so custom label keys can be aggregated in reports too. Values flow through the existing comma-joined `groupings` → `aggregate=` path.
- Adds `label:app.kubernetes.io/name` as a built-in example on both surfaces so users discover the format without needing documentation — the Kubernetes recommended label is set by Helm on virtually all charts and is present in the vast majority of clusters.
- Wraps the reports ComboBox in `<Theme theme="white">` so it renders light regardless of the user's OS/app theme, matching the side panel's hard-coded light Tailwind styling.

## Does this PR relate to any other PRs?

- None.

## How will this PR impact users?

- Users can aggregate cost data by any Kubernetes label without leaving the UI. Previously the workload-type Select was the only option, and aggregating by label required hand-editing the URL or hitting the API directly.
- Discoverability: `label:app.kubernetes.io/name` is now visible as a preset, hinting at the `label:<key>` format for users who don't know it.
- No backwards-incompatible changes to existing presets — typed values that match a preset (`namespace`, `deployment`, etc.) behave exactly as before.

## Does this PR address any GitHub or Zendesk issues?

- Related to opencost/opencost#2528 (UI request for label aggregation without manual URL manipulation). Cross-repo, so this PR does not auto-close it.

## How was this PR tested?

- Manual: in a dev build pointed at a real cluster, selected the new `label:app.kubernetes.io/name` preset on both the home page and the Report Builder and confirmed `/allocation/compute` was called with `aggregate=label:app.kubernetes.io/name` and the chart/table rendered the expected aggregation.
- Manual: typed bare keys (e.g. `version`) and verified they submitted as `label:version`; typed prefixed values (e.g. `annotation:foo`) and verified they passed through unchanged.
- Manual: verified the Groupings ComboBox renders with light styling whether the app is in `cds--white` or `cds--g100` theme.
- `npm run typecheck` — no new type errors introduced (the 57 pre-existing legacy errors are unchanged).

## Does this PR require changes to documentation?

- No. The `label:<key>` form is already supported by `/allocation/compute`; this PR only surfaces it in the UI. The preset itself serves as inline documentation of the format.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

- Yes — small, additive, low-risk UI change. Targeting the next release.