### PR TITLE
fix(allocation): render distinct hourly bars on home page chart

### DIFF
--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -90,11 +90,20 @@ function topNPerDay(
   return { top, other, idle };
 }
 
-function getDateLabel(alloc: AllocationLike): string {
+function getDateLabel(alloc: AllocationLike, accumulate: string): string {
   const start = alloc?.window?.start ?? alloc?.start;
   if (!start || String(start).trim().length === 0) return "?";
   const d = new Date(start as string);
   if (Number.isNaN(d.getTime()) || d.getUTCFullYear() < 1971) return "?";
+  if (accumulate === "hour") {
+    return d.toLocaleString("en-US", {
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      hour12: false,
+      timeZone: "UTC",
+    });
+  }
   return d.toLocaleDateString("en-US", {
     month: "2-digit",
     day: "2-digit",
@@ -107,6 +116,7 @@ function buildChartData(
   topN: number,
   includeIdle: boolean,
   includeUnallocated: boolean,
+  accumulate: string,
 ): ChartPoint[] {
   const points: ChartPoint[] = [];
 
@@ -124,7 +134,7 @@ function buildChartData(
       topN,
       (a) => a.totalCost ?? 0,
     );
-    const date = getDateLabel(allocs[0]);
+    const date = getDateLabel(allocs[0], accumulate);
 
     for (const a of top) {
       const k = a.name ?? "?";
@@ -208,9 +218,9 @@ export default function CostAllocationChart({
   const chartData = useMemo(
     () =>
       rawData.length > 0
-        ? buildChartData(rawData, topN, includeIdle, includeUnallocated)
+        ? buildChartData(rawData, topN, includeIdle, includeUnallocated, accumulate)
         : [],
-    [rawData, topN, includeIdle, includeUnallocated],
+    [rawData, topN, includeIdle, includeUnallocated, accumulate],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## What does this PR change?

- Fixes a bug in the home-page Cost Allocation chart where selecting `Hourly` granularity collapsed all 24 hourly buckets into a single bar. Carbon Charts stacks bars that share the same `group` field, and `getDateLabel` returned only month/day — so every hourly bucket received the same `MM/DD` group label and merged together.
- `getDateLabel` now includes the hour (`MM/DD HH`) when `accumulate === "hour"`. Other granularities (day, week, month, quarter, all) are unchanged because their bucket starts already produce distinct month/day labels.

## Does this PR relate to any other PRs?

- None.

## How will this PR impact users?

- Users selecting `Hourly` granularity on the home page Cost Allocation chart will now see one bar per hour instead of a single merged bar. The data was always being fetched correctly from `/allocation/compute` — only the rendering was wrong.
- No impact on the Report Builder: it uses recharts, which renders each data point as a separate bar regardless of duplicate labels, so its hourly view was already correct.

## Does this PR address any GitHub or Zendesk issues?

- None.

## How was this PR tested?

- Manual: on the home page Cost Allocation chart, set Granularity to `Hourly` with `Window=Yesterday` and confirmed 24 distinct bars rendered (one per UTC hour), each labelled `MM/DD HH`.
- `npm run typecheck` — no new type errors introduced (the 57 pre-existing legacy errors are unchanged).

## Does this PR require changes to documentation?

- No. Pure bug fix in chart rendering; the API contract and UI surface are unchanged.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

- Yes — small, low-risk bug fix. Targeting the next release.