### PR TITLE
fix(allocation): correctly stack bars on home page Cost Allocation chart

### DIFF
--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -244,6 +244,7 @@ export default function CostAllocationChart({
         left: {
           mapsTo: "value",
           scaleType: ScaleTypes.LINEAR,
+          stacked: true,
           ticks: {
             formatter: (v: number | Date) =>
               toCurrency(typeof v === "number" ? v : v.getTime(), currency),

--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -125,8 +125,6 @@ function buildChartData(
     for (const a of other) {
       points.push({ group: date, key: "other", value: a.totalCost ?? 0 });
     }
-    const totalCost = allocs.reduce((s, a) => s + (a.totalCost ?? 0), 0);
-    points.push({ group: date, key: "total", value: totalCost });
     if (includeIdle && idle.length > 0) {
       const idleCost = idle.reduce((s, a) => s + (a.totalCost ?? 0), 0);
       if (idleCost > 0) {
@@ -144,7 +142,6 @@ function buildColorScale(points: ChartPoint[]): Record<string, string> {
   let p = 0;
   for (const k of keys) {
     if (k === "idle") scale[k] = greyscale[1];
-    else if (k === "total") scale[k] = greyscale[2];
     else if (k === "other") scale[k] = browns[0];
     else scale[k] = primary[p++ % primary.length];
   }
@@ -281,7 +278,6 @@ export default function CostAllocationChart({
                 typeof item.value === "number"
                   ? item.value
                   : parseFloat(item.value) || 0;
-              if (item.key === "total") return null;
               total += val;
               const name =
                 item.label ?? item.key ?? item.name ?? item.group ?? "—";


### PR DESCRIPTION
## What does this PR change?

- Removes a synthetic `{key: "total", value: sum}` point that was being pushed onto the home-page Cost Allocation chart's stack. The tooltip suppressed it (`Total:` re-summed the categories), but it was always the tallest single segment in each bucket — which masked a second, deeper bug.
- Adds `axes.left.stacked: true` to the chart options. Carbon's `<StackedBarChart>` does not, on its own, scale the y-axis to fit stacked totals; without this flag the y-axis was auto-scaling to the largest single category, clipping the remainder of each stack above the visible plot area.
- Removes the now-dead `greyscale[2]` colour-scale entry and tooltip suppression branch tied to the synthetic `total` key.

## Does this PR relate to any other PRs?

- None.

## How will this PR impact users?

- Bars on the home-page Cost Allocation chart now render to their true stacked height. Previously, when totals exceeded the largest single category, the upper portion of each bar was clipped off the chart and the y-axis maximum was too low (e.g. a bucket whose categories summed to $14.78 was being rendered as a ~$5.50 bar against a $6 y-axis).
- The cosmetic "grey total bar reaching above category segments" is gone — the visible stack now equals the total by definition.
- No impact on the Report Builder chart: it uses recharts and was already stacking correctly.

## Does this PR address any GitHub or Zendesk issues?

- None.

## How was this PR tested?

- Manual: home page Cost Allocation chart with `Window=Last 7 days`, `Daily` granularity, `Namespace` aggregation. Confirmed bars now reach their full stacked height, the y-axis auto-scales to the largest stacked total across the window, and the tooltip's `Total:` value matches the visible bar height.
- Manual: toggled `Include idle costs` on/off to confirm the idle segment stacks correctly with the rest.
- `npm run typecheck` — no new type errors introduced (the 57 pre-existing legacy errors are unchanged).

## Does this PR require changes to documentation?

- No. Pure bug fix in chart rendering; the API contract and UI surface are unchanged.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

- Yes — bug fix correcting visibly-wrong chart rendering, low-risk change scoped to one component. Targeting the next release.