### PR TITLE
feat(allocation): add Include unallocated costs toggle

### DIFF
--- a/app/components/allocation-filters-context.tsx
+++ b/app/components/allocation-filters-context.tsx
@@ -32,6 +32,7 @@ export function useAllocationFilters(
     aggregateBy: DEFAULT_ALLOCATION_FILTERS.allocationAggregateBy,
     accumulate: DEFAULT_ALLOCATION_FILTERS.allocationAccumulate,
     includeIdle: DEFAULT_ALLOCATION_FILTERS.allocationIncludeIdle,
+    includeUnallocated: DEFAULT_ALLOCATION_FILTERS.allocationIncludeUnallocated,
     drilldownAggregateBy: undefined,
     drilldownFilters: [],
   });
@@ -54,6 +55,7 @@ export function AllocationFiltersProvider({
     aggregateBy: DEFAULT_ALLOCATION_FILTERS.allocationAggregateBy,
     accumulate: DEFAULT_ALLOCATION_FILTERS.allocationAccumulate,
     includeIdle: DEFAULT_ALLOCATION_FILTERS.allocationIncludeIdle,
+    includeUnallocated: DEFAULT_ALLOCATION_FILTERS.allocationIncludeUnallocated,
     drilldownAggregateBy: undefined,
     drilldownFilters: [],
   });

--- a/app/components/cost-allocation-chart.tsx
+++ b/app/components/cost-allocation-chart.tsx
@@ -58,6 +58,10 @@ function isIdle(alloc: AllocationLike): boolean {
   return ((alloc.name ?? "") as string).indexOf("__idle__") >= 0;
 }
 
+function isUnallocated(alloc: AllocationLike): boolean {
+  return ((alloc.name ?? "") as string).indexOf("__unallocated__") >= 0;
+}
+
 function aggregateAllocs(
   allocs: AllocationLike[],
   name: string,
@@ -102,13 +106,17 @@ function buildChartData(
   rawData: any[],
   topN: number,
   includeIdle: boolean,
+  includeUnallocated: boolean,
 ): ChartPoint[] {
   const points: ChartPoint[] = [];
 
   for (const set of rawData) {
-    const allocs: AllocationLike[] = Array.isArray(set)
+    const allRaw: AllocationLike[] = Array.isArray(set)
       ? set
       : (Object.values(set) as AllocationLike[]);
+    const allocs: AllocationLike[] = includeUnallocated
+      ? allRaw
+      : allRaw.filter((a) => !isUnallocated(a));
     if (!allocs.length) continue;
 
     const { top, other, idle } = topNPerDay(
@@ -158,6 +166,7 @@ export interface CostAllocationChartProps {
   aggregateBy?: string;
   accumulate?: string;
   includeIdle?: boolean;
+  includeUnallocated?: boolean;
   currency?: string;
   topN?: number;
   useSharedFilters?: boolean;
@@ -170,6 +179,7 @@ export default function CostAllocationChart({
   aggregateBy: aggregateByProp,
   accumulate: accumulateProp,
   includeIdle: includeIdleProp,
+  includeUnallocated: includeUnallocatedProp,
   currency: currencyProp,
   topN = 10,
   useSharedFilters = false,
@@ -186,6 +196,8 @@ export default function CostAllocationChart({
     sharedFilters.aggregateBy;
   const accumulate = accumulateProp ?? sharedFilters.accumulate;
   const includeIdle = includeIdleProp ?? sharedFilters.includeIdle;
+  const includeUnallocated =
+    includeUnallocatedProp ?? sharedFilters.includeUnallocated;
   const currency = currencyProp ?? defaultCurrency;
   const drilldownFilters = useSharedFilters
     ? (sharedFilters.drilldownFilters ?? [])
@@ -198,8 +210,10 @@ export default function CostAllocationChart({
   const chartTitle = generateTitle(window, aggregateBy, accumulate);
   const chartData = useMemo(
     () =>
-      rawData.length > 0 ? buildChartData(rawData, topN, includeIdle) : [],
-    [rawData, topN, includeIdle],
+      rawData.length > 0
+        ? buildChartData(rawData, topN, includeIdle, includeUnallocated)
+        : [],
+    [rawData, topN, includeIdle, includeUnallocated],
   );
 
   useEffect(() => {
@@ -323,10 +337,12 @@ export default function CostAllocationChart({
             aggregateBy={aggregateBy}
             accumulate={accumulate}
             includeIdle={includeIdle}
+            includeUnallocated={includeUnallocated}
             onWindowChange={(v) => setFilter("window", v)}
             onAggregateByChange={(v) => setFilter("aggregateBy", v)}
             onAccumulateChange={(v) => setFilter("accumulate", v)}
             onIncludeIdleChange={(v) => setFilter("includeIdle", v)}
+            onIncludeUnallocatedChange={(v) => setFilter("includeUnallocated", v)}
             idPrefix="chart-alloc"
           />
         }

--- a/app/components/cost-allocation-table.tsx
+++ b/app/components/cost-allocation-table.tsx
@@ -80,6 +80,7 @@ export interface CostAllocationTableProps {
   aggregateBy?: string;
   accumulate?: string;
   includeIdle?: boolean;
+  includeUnallocated?: boolean;
   currency?: string;
   useSharedFilters?: boolean;
 }
@@ -91,6 +92,7 @@ export default function CostAllocationTable({
   aggregateBy: globalAggregateByProp,
   accumulate: accumulateProp,
   includeIdle: includeIdleProp,
+  includeUnallocated: includeUnallocatedProp,
   currency: currencyProp,
   useSharedFilters = false,
 }: CostAllocationTableProps) {
@@ -102,6 +104,8 @@ export default function CostAllocationTable({
   const globalAggregateBy = globalAggregateByProp ?? sharedFilters.aggregateBy;
   const accumulate = accumulateProp ?? sharedFilters.accumulate;
   const includeIdle = includeIdleProp ?? sharedFilters.includeIdle;
+  const includeUnallocated =
+    includeUnallocatedProp ?? sharedFilters.includeUnallocated;
   const currency = currencyProp ?? defaultCurrency;
 
   const [localDrilldownFilters, setLocalDrilldownFilters] = useState<
@@ -150,15 +154,31 @@ export default function CostAllocationTable({
 
   const dataTitle = generateTitle(window, aggregateBy, accumulate);
 
+  const filteredAllocationData = useMemo(() => {
+    if (includeUnallocated) return allocationData;
+    return allocationData.map((set: any) => {
+      if (Array.isArray(set)) {
+        return set.filter(
+          (a: any) => !String(a?.name ?? "").includes("__unallocated__"),
+        );
+      }
+      const next: Record<string, any> = {};
+      for (const [name, alloc] of Object.entries(set ?? {})) {
+        if (!name.includes("__unallocated__")) next[name] = alloc;
+      }
+      return next;
+    });
+  }, [allocationData, includeUnallocated]);
+
   const cumulativeData = useMemo(() => {
-    const cumulative = rangeToCumulative(allocationData, aggregateBy);
+    const cumulative = rangeToCumulative(filteredAllocationData, aggregateBy);
     return cumulative ? toArray(cumulative) : [];
-  }, [allocationData, aggregateBy]);
+  }, [filteredAllocationData, aggregateBy]);
 
   const totalData = useMemo(() => {
-    const cumulative = rangeToCumulative(allocationData, aggregateBy);
+    const cumulative = rangeToCumulative(filteredAllocationData, aggregateBy);
     return cumulative ? cumulativeToTotals(cumulative) : {};
-  }, [allocationData, aggregateBy]);
+  }, [filteredAllocationData, aggregateBy]);
 
   const sortedRows = useMemo(() => {
     const sorted = sortBy(cumulativeData, (r) => {
@@ -379,10 +399,14 @@ export default function CostAllocationTable({
               aggregateBy={globalAggregateBy}
               accumulate={accumulate}
               includeIdle={includeIdle}
+              includeUnallocated={includeUnallocated}
               onWindowChange={(v) => setFilter("window", v)}
               onAggregateByChange={(v) => setFilter("aggregateBy", v)}
               onAccumulateChange={(v) => setFilter("accumulate", v)}
               onIncludeIdleChange={(v) => setFilter("includeIdle", v)}
+              onIncludeUnallocatedChange={(v) =>
+                setFilter("includeUnallocated", v)
+              }
               idPrefix="table-alloc"
             />
           }

--- a/app/components/report-builder-side-panel.tsx
+++ b/app/components/report-builder-side-panel.tsx
@@ -617,6 +617,19 @@ export default function ReportBuilderSidePanel({
         </label>
       ) : null}
 
+      {allocationQuery ? (
+        <label className="mb-4 flex items-center gap-2 text-sm text-[#393939]">
+          <input
+            type="checkbox"
+            checked={allocationQuery.includeUnallocated}
+            onChange={(event) =>
+              updateQuery({ includeUnallocated: event.target.checked })
+            }
+          />
+          Include unallocated costs
+        </label>
+      ) : null}
+
       <div className="overflow-visible border-t border-[#e0e0e0] pt-4 pb-4">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="m-0 text-base font-semibold text-[#262626]">Filters</h3>

--- a/app/components/scoped-views.tsx
+++ b/app/components/scoped-views.tsx
@@ -38,6 +38,7 @@ export const DEFAULT_ALLOCATION_FILTERS = {
   allocationAggregateBy: "namespace",
   allocationAccumulate: "day",
   allocationIncludeIdle: true,
+  allocationIncludeUnallocated: true,
 };
 
 export const DEFAULT_CLOUD_FILTERS = {
@@ -52,6 +53,7 @@ export interface AllocationFilterValues {
   /** `/allocation/compute` `accumulate` param (e.g. `day`, `weeknow`, `all`). */
   accumulate: string;
   includeIdle: boolean;
+  includeUnallocated: boolean;
   drilldownAggregateBy?: string;
   drilldownFilters?: { property: string; value: string }[];
 }
@@ -159,10 +161,12 @@ interface AllocationFilterControlsProps {
   aggregateBy: string;
   accumulate: string;
   includeIdle: boolean;
+  includeUnallocated?: boolean;
   onWindowChange: (v: string) => void;
   onAggregateByChange: (v: string) => void;
   onAccumulateChange: (v: string) => void;
   onIncludeIdleChange: (v: boolean) => void;
+  onIncludeUnallocatedChange?: (v: boolean) => void;
   idPrefix?: string;
   compact?: boolean;
 }
@@ -172,10 +176,12 @@ export function AllocationFilterControls({
   aggregateBy,
   accumulate,
   includeIdle,
+  includeUnallocated,
   onWindowChange,
   onAggregateByChange,
   onAccumulateChange,
   onIncludeIdleChange,
+  onIncludeUnallocatedChange,
   idPrefix = "alloc",
   compact = true,
 }: AllocationFilterControlsProps) {
@@ -229,6 +235,16 @@ export function AllocationFilterControls({
         />
         Include idle costs
       </label>
+      {onIncludeUnallocatedChange ? (
+        <label className="flex items-end gap-2 text-sm cursor-pointer pb-2">
+          <input
+            type="checkbox"
+            checked={includeUnallocated !== false}
+            onChange={(e) => onIncludeUnallocatedChange(e.target.checked)}
+          />
+          Include unallocated costs
+        </label>
+      ) : null}
     </div>
   );
 }

--- a/app/services/report-query.ts
+++ b/app/services/report-query.ts
@@ -393,11 +393,26 @@ export async function runAllocationReport(
     filters: query.filters.length > 0 ? parseFilters(query.filters) : undefined,
   });
 
-  const rawSets = Array.isArray(response?.data)
+  const rawSetsAll = Array.isArray(response?.data)
     ? response.data
     : Array.isArray(response)
       ? response
       : [];
+
+  const rawSets = query.includeUnallocated
+    ? rawSetsAll
+    : rawSetsAll.map((set: any) => {
+        if (Array.isArray(set)) {
+          return set.filter(
+            (a: any) => !String(a?.name ?? "").includes("__unallocated__"),
+          );
+        }
+        const next: Record<string, any> = {};
+        for (const [name, alloc] of Object.entries(set ?? {})) {
+          if (!name.includes("__unallocated__")) next[name] = alloc;
+        }
+        return next;
+      });
 
   const cumulativeKey = groupings[0] ?? "name";
   const cumulative = rangeToCumulative(rawSets, cumulativeKey);

--- a/app/types/report.ts
+++ b/app/types/report.ts
@@ -53,6 +53,7 @@ export interface AllocationReportQuery {
   window: string;
   accumulate: string;
   includeIdle: boolean;
+  includeUnallocated: boolean;
   measures: AllocationMeasure[];
   groupings: string[];
   filters: ReportFilterRule[];
@@ -216,6 +217,7 @@ export function createDefaultAllocationReportQuery(): AllocationReportQuery {
     window: getYesterdayUtcRange(),
     accumulate: "day",
     includeIdle: true,
+    includeUnallocated: true,
     measures: ["totalCost"],
     groupings: ["namespace"],
     filters: [],
@@ -365,6 +367,10 @@ function normalizeAllocationQuery(raw: unknown): AllocationReportQuery {
     accumulate,
     includeIdle:
       typeof record.includeIdle === "boolean" ? record.includeIdle : defaults.includeIdle,
+    includeUnallocated:
+      typeof record.includeUnallocated === "boolean"
+        ? record.includeUnallocated
+        : defaults.includeUnallocated,
     measures,
     groupings,
     filters: normalizeFilters(record.filters),


### PR DESCRIPTION
## What does this PR change?

- Adds an `Include unallocated costs` checkbox next to the existing `Include idle costs` checkbox in both:
  - The home-page Cost Allocation chart and table (driven by the shared `AllocationFiltersProvider` context, so flipping the toggle in either widget updates both).
  - The Report Builder side panel for allocation reports.
- Threads a new `includeUnallocated: boolean` field through `AllocationFilterValues` (shared filter state), `AllocationReportQuery` (report query type + defaults + normalization), and `DEFAULT_ALLOCATION_FILTERS`. Defaults to `true` to preserve current behavior.
- When the toggle is OFF, applies a client-side filter that drops any allocation whose name contains `__unallocated__` before chart/table aggregation. The fetch result is unchanged; only post-processing differs, so toggling is instantaneous and doesn't trigger a refetch.

## Does this PR relate to any other PRs?

- Stack-mate of the in-flight allocation chart improvements:
  - `feat(allocation): custom label aggregation in home + report dropdowns` (feat/allocation-label-aggregation)
  - `fix(allocation): render distinct hourly bars on home page chart` (fix/allocation-chart-hourly-buckets)
  - `fix(allocation): correctly stack bars on home page Cost Allocation chart` (fix/allocation-chart-double-stacked-total)
- This PR is independent — branched off `main` — and can merge in any order with the others. There's a minor conflict in `cost-allocation-chart.tsx::buildChartData` against the granularity-fix PR (both add a parameter to the same signature); whichever lands second will need a trivial rebase.

## How will this PR impact users?

- Users aggregating cost by a field where many resources lack a value (most commonly a Kubernetes label) can now hide `__unallocated__` from charts and tables with one click. Previously this bucket often dwarfed every real category and made the rest of the data unreadable.
- Default-ON behavior means no surprise for existing users — `__unallocated__` continues to appear unless the user opts to hide it.
- The Cost Summary Cards intentionally do not expose the toggle — their job is to report true total cluster cost, which by definition includes unallocated resources.

## Does this PR address any GitHub or Zendesk issues?

- None.

## How was this PR tested?

- Manual: against a real cluster, set aggregate to `label:app.kubernetes.io/name` on the home-page Cost Allocation chart and confirmed `__unallocated__` segments disappear from the bars (and rows from the table) when the toggle is OFF, and reappear when ON, with no network request triggered between toggles.
- Manual: same flow on the Report Builder for an allocation report — confirmed the chart, the `Total:` figure, and the row table all reflect the filter.
- Manual: confirmed toggling on/off doesn't refetch (Network tab unchanged).
- Manual: confirmed the toggle does not appear on the Cost Summary Cards widget (intentional — kept their `AllocationFilterControls` call site free of `onIncludeUnallocatedChange`).
- `npm run typecheck` — no new type errors introduced (the 57 pre-existing legacy errors are unchanged).

## Does this PR require changes to documentation?

- No. The toggle is self-explanatory and follows the same UX pattern as the existing `Include idle costs` checkbox.

## Have you labeled this PR and its corresponding Issue as "next release" if it should be part of the next OpenCost release? If not, why not?

- Yes — small, additive, default-preserving UI change. Targeting the next release.